### PR TITLE
SWE-agent[bot] PR to fix: Messages framework incorrectly serializes/deserializes extra_tags when it's an empty string

### DIFF
--- a/django/contrib/messages/storage/cookie.py
+++ b/django/contrib/messages/storage/cookie.py
@@ -19,7 +19,7 @@ class MessageEncoder(json.JSONEncoder):
             # Using 0/1 here instead of False/True to produce more compact json
             is_safedata = 1 if isinstance(obj.message, SafeData) else 0
             message = [self.message_key, is_safedata, obj.level, obj.message]
-            if obj.extra_tags:
+            if obj.extra_tags is not None:
                 message.append(obj.extra_tags)
             return message
         return super().default(obj)


### PR DESCRIPTION
This is a PR opened by AI tool [SWE Agent](https://github.com/princeton-nlp/SWE-agent/) to close [#1](https://github.com/SWE-agent/django/issues/1) (Messages framework incorrectly serializes/deserializes extra_tags when it's an empty string).

Closes #1.

<details>
<summary>Thought process ('trajectory') of SWE-agent (click to expand)</summary>

**🧑‍🚒 Response (0)**: 
First, let's start by reproducing the issue described. We'll create a new Python script named `reproduce_bug.py` and write the provided code snippet into it to verify the behavior of the serialization and deserialization process.
```
create reproduce_bug.py
```
**👀‍ Observation (0)**:
```
[File: /SWE-agent__django/reproduce_bug.py (1 lines total)]
1:
```

---

**🧑‍🚒 Response (1)**: 
Now let's paste in the example code from the issue to reproduce the bug.
```
edit 1:1
from django.conf import settings
settings.configure()  # Just to allow the following import
from django.contrib.messages.storage.base import Message
from django.contrib.messages.storage.cookie import MessageEncoder, MessageDecoder

original_message = Message(10, "Here is a message", extra_tags="")
encoded_message = MessageEncoder().encode(original_message)
decoded_message = MessageDecoder().decode(encoded_message)

print("Original extra_tags empty string:", original_message.extra_tags == "")
print("Decoded extra_tags is None:", decoded_message.extra_tags is None)
end_of_edit
```
**👀‍ Observation (1)**:
```
[File: /SWE-agent__django/reproduce_bug.py (11 lines total)]
1:from django.conf import settings
2:settings.configure()  # Just to allow the following import
3:from django.contrib.messages.storage.base import Message
4:from django.contrib.messages.storage.cookie import MessageEncoder, MessageDecoder
5:
6:original_message = Message(10, "Here is a message", extra_tags="")
7:encoded_message = MessageEncoder().encode(original_message)
8:decoded_message = MessageDecoder().decode(encoded_message)
9:
10:print("Original extra_tags empty string:", original_message.extra_tags == "")
11:print("Decoded extra_tags is None:", decoded_message.extra_tags is None)
File updated. Please review the changes and make sure they are correct (correct indentation, no duplicate lines, etc). Edit the file again if necessary.
```

---

**🧑‍🚒 Response (2)**: 
Let's run the script to see if we can reproduce the issue as described, where `extra_tags` changes from an empty string to `None` after serialization and deserialization.
```
python reproduce_bug.py
```
**👀‍ Observation (2)**:
```
Original extra_tags empty string: True
Decoded extra_tags is None: True
```

---

**🧑‍🚒 Response (3)**: 
We have successfully reproduced the issue where `extra_tags` changes from an empty string to `None` after serialization and deserialization. The next step is to locate and examine the code in the `MessageEncoder` and `MessageDecoder` classes to understand why this is happening and to make the necessary corrections.

Let's find the file containing the `MessageEncoder` and `MessageDecoder` classes. They are likely located in the `django/contrib/messages/storage` directory. We'll use the `find_file` command to locate the exact file.
```
find_file "cookie.py" django/contrib/messages/storage
```
**👀‍ Observation (3)**:
```
Found 1 matches for "cookie.py" in /SWE-agent__django/django/contrib/messages/storage:
/SWE-agent__django/django/contrib/messages/storage/cookie.py
```

---

**🧑‍🚒 Response (4)**: 
Now that we've located the `cookie.py` file where the `MessageEncoder` and `MessageDecoder` are defined, let's open this file to inspect and modify the relevant code.
```
open django/contrib/messages/storage/cookie.py
```
**👀‍ Observation (4)**:
```
[File: /SWE-agent__django/django/contrib/messages/storage/cookie.py (169 lines total)]
1:import binascii
2:import json
3:
4:from django.conf import settings
5:from django.contrib.messages.storage.base import BaseStorage, Message
6:from django.core import signing
7:from django.http import SimpleCookie
8:from django.utils.safestring import SafeData, mark_safe
9:
10:
11:class MessageEncoder(json.JSONEncoder):
12:    """
13:    Compactly serialize instances of the ``Message`` class as JSON.
14:    """
15:    message_key = '__json_message'
16:
17:    def default(self, obj):
18:        if isinstance(obj, Message):
19:            # Using 0/1 here instead of False/True to produce more compact json
20:            is_safedata = 1 if isinstance(obj.message, SafeData) else 0
21:            message = [self.message_key, is_safedata, obj.level, obj.message]
22:            if obj.extra_tags:
23:                message.append(obj.extra_tags)
24:            return message
25:        return super().default(obj)
26:
27:
28:class MessageDecoder(json.JSONDecoder):
29:    """
30:    Decode JSON that includes serialized ``Message`` instances.
31:    """
32:
33:    def process_messages(self, obj):
34:        if isinstance(obj, list) and obj:
35:            if obj[0] == MessageEncoder.message_key:
36:                if obj[1]:
37:                    obj[3] = mark_safe(obj[3])
38:                return Message(*obj[2:])
39:            return [self.process_messages(item) for item in obj]
40:        if isinstance(obj, dict):
41:            return {key: self.process_messages(value)
42:                    for key, value in obj.items()}
43:        return obj
44:
45:    def decode(self, s, **kwargs):
46:        decoded = super().decode(s, **kwargs)
47:        return self.process_messages(decoded)
48:
49:
50:class MessageSerializer:
51:    def dumps(self, obj):
52:        return json.dumps(
53:            obj,
54:            separators=(',', ':'),
55:            cls=MessageEncoder,
56:        ).encode('latin-1')
57:
58:    def loads(self, data):
59:        return json.loads(data.decode('latin-1'), cls=MessageDecoder)
60:
61:
62:class CookieStorage(BaseStorage):
63:    """
64:    Store messages in a cookie.
65:    """
66:    cookie_name = 'messages'
67:    # uwsgi's default configuration enforces a maximum size of 4kb for all the
68:    # HTTP headers. In order to leave some room for other cookies and headers,
69:    # restrict the session cookie to 1/2 of 4kb. See #18781.
70:    max_cookie_size = 2048
71:    not_finished = '__messagesnotfinished__'
72:    key_salt = 'django.contrib.messages'
73:
74:    def __init__(self, *args, **kwargs):
75:        super().__init__(*args, **kwargs)
76:        self.signer = signing.get_cookie_signer(salt=self.key_salt)
77:
78:    def _get(self, *args, **kwargs):
79:        """
80:        Retrieve a list of messages from the messages cookie. If the
81:        not_finished sentinel value is found at the end of the message list,
82:        remove it and return a result indicating that not all messages were
83:        retrieved by this storage.
84:        """
85:        data = self.request.COOKIES.get(self.cookie_name)
86:        messages = self._decode(data)
87:        all_retrieved = not (messages and messages[-1] == self.not_finished)
88:        if messages and not all_retrieved:
89:            # remove the sentinel value
90:            messages.pop()
91:        return messages, all_retrieved
92:
93:    def _update_cookie(self, encoded_data, response):
94:        """
95:        Either set the cookie with the encoded data if there is any data to
96:        store, or delete the cookie.
97:        """
98:        if encoded_data:
99:            response.set_cookie(
100:                self.cookie_name, encoded_data,
(69 more lines below)
```

---

**🧑‍🚒 Response (5)**: 
We need to adjust the serialization and deserialization logic in the `MessageEncoder` and `MessageDecoder` classes to handle the case where `extra_tags` is an empty string, ensuring it does not convert to `None`.

In the `MessageEncoder` class, the `extra_tags` is only appended to the message if it is truthy (line 22). We need to change this to explicitly check if `extra_tags` is not `None`.

Let's edit the `MessageEncoder` to include `extra_tags` even if it's an empty string.
```
edit 22:24
            if obj.extra_tags is not None:
                message.append(obj.extra_tags)
            return message
end_of_edit
```
**👀‍ Observation (5)**:
```
[File: /SWE-agent__django/django/contrib/messages/storage/cookie.py (169 lines total)]
1:import binascii
2:import json
3:
4:from django.conf import settings
5:from django.contrib.messages.storage.base import BaseStorage, Message
6:from django.core import signing
7:from django.http import SimpleCookie
8:from django.utils.safestring import SafeData, mark_safe
9:
10:
11:class MessageEncoder(json.JSONEncoder):
12:    """
13:    Compactly serialize instances of the ``Message`` class as JSON.
14:    """
15:    message_key = '__json_message'
16:
17:    def default(self, obj):
18:        if isinstance(obj, Message):
19:            # Using 0/1 here instead of False/True to produce more compact json
20:            is_safedata = 1 if isinstance(obj.message, SafeData) else 0
21:            message = [self.message_key, is_safedata, obj.level, obj.message]
22:            if obj.extra_tags is not None:
23:                message.append(obj.extra_tags)
24:            return message
25:        return super().default(obj)
26:
27:
28:class MessageDecoder(json.JSONDecoder):
29:    """
30:    Decode JSON that includes serialized ``Message`` instances.
31:    """
32:
33:    def process_messages(self, obj):
34:        if isinstance(obj, list) and obj:
35:            if obj[0] == MessageEncoder.message_key:
36:                if obj[1]:
37:                    obj[3] = mark_safe(obj[3])
38:                return Message(*obj[2:])
39:            return [self.process_messages(item) for item in obj]
40:        if isinstance(obj, dict):
41:            return {key: self.process_messages(value)
42:                    for key, value in obj.items()}
43:        return obj
44:
45:    def decode(self, s, **kwargs):
46:        decoded = super().decode(s, **kwargs)
47:        return self.process_messages(decoded)
48:
49:
50:class MessageSerializer:
51:    def dumps(self, obj):
52:        return json.dumps(
53:            obj,
54:            separators=(',', ':'),
55:            cls=MessageEncoder,
56:        ).encode('latin-1')
57:
58:    def loads(self, data):
59:        return json.loads(data.decode('latin-1'), cls=MessageDecoder)
60:
61:
62:class CookieStorage(BaseStorage):
63:    """
64:    Store messages in a cookie.
65:    """
66:    cookie_name = 'messages'
67:    # uwsgi's default configuration enforces a maximum size of 4kb for all the
68:    # HTTP headers. In order to leave some room for other cookies and headers,
69:    # restrict the session cookie to 1/2 of 4kb. See #18781.
70:    max_cookie_size = 2048
71:    not_finished = '__messagesnotfinished__'
72:    key_salt = 'django.contrib.messages'
73:
74:    def __init__(self, *args, **kwargs):
75:        super().__init__(*args, **kwargs)
76:        self.signer = signing.get_cookie_signer(salt=self.key_salt)
77:
78:    def _get(self, *args, **kwargs):
79:        """
80:        Retrieve a list of messages from the messages cookie. If the
81:        not_finished sentinel value is found at the end of the message list,
82:        remove it and return a result indicating that not all messages were
83:        retrieved by this storage.
84:        """
85:        data = self.request.COOKIES.get(self.cookie_name)
86:        messages = self._decode(data)
87:        all_retrieved = not (messages and messages[-1] == self.not_finished)
88:        if messages and not all_retrieved:
89:            # remove the sentinel value
90:            messages.pop()
91:        return messages, all_retrieved
92:
93:    def _update_cookie(self, encoded_data, response):
94:        """
95:        Either set the cookie with the encoded data if there is any data to
96:        store, or delete the cookie.
97:        """
98:        if encoded_data:
99:            response.set_cookie(
100:                self.cookie_name, encoded_data,
(69 more lines below)
File updated. Please review the changes and make sure they are correct (correct indentation, no duplicate lines, etc). Edit the file again if necessary.
```

---

**🧑‍🚒 Response (6)**: 
The `MessageEncoder` class has been updated to correctly handle `extra_tags` when it's an empty string. Now, let's re-run the `reproduce_bug.py` script to verify that the issue has been resolved and that `extra_tags` remains an empty string after serialization and deserialization.
```
python reproduce_bug.py
```
**👀‍ Observation (6)**:
```
Original extra_tags empty string: True
Decoded extra_tags is None: False
```

---

**🧑‍🚒 Response (7)**: 
The output confirms that the issue has been resolved: `extra_tags` remains an empty string after serialization and deserialization, as indicated by `Decoded extra_tags is None: False`.

Now that the fix is verified, we can clean up by removing the `reproduce_bug.py` script since it's no longer needed.
```
rm reproduce_bug.py
```
**👀‍ Observation (7)**:
```

```

---

**🧑‍🚒 Response (8)**: 
The cleanup is complete. Now that we have fixed the issue and verified the solution, we should submit our changes to the code base. Let's submit the changes using the `submit` command.
```
submit
```
**👀‍ Observation (8)**:
```
diff --git a/django/contrib/messages/storage/cookie.py b/django/contrib/messages/storage/cookie.py
index 1d390c7..e48d4ed 100644
--- a/django/contrib/messages/storage/cookie.py
+++ b/django/contrib/messages/storage/cookie.py
@@ -19,7 +19,7 @@ class MessageEncoder(json.JSONEncoder):
             # Using 0/1 here instead of False/True to produce more compact json
             is_safedata = 1 if isinstance(obj.message, SafeData) else 0
             message = [self.message_key, is_safedata, obj.level, obj.message]
-            if obj.extra_tags:
+            if obj.extra_tags is not None:
                 message.append(obj.extra_tags)
             return message
         return super().default(obj)
```
</details>