### PR TITLE
SWE-agent[bot] PR to fix: Messages framework incorrectly serializes/deserializes extra_tags when it's an empty string

### DIFF
--- a/django/contrib/messages/storage/cookie.py
+++ b/django/contrib/messages/storage/cookie.py
@@ -19,7 +19,7 @@ class MessageEncoder(json.JSONEncoder):
             # Using 0/1 here instead of False/True to produce more compact json
             is_safedata = 1 if isinstance(obj.message, SafeData) else 0
             message = [self.message_key, is_safedata, obj.level, obj.message]
-            if obj.extra_tags:
+            if obj.extra_tags is not None:
                 message.append(obj.extra_tags)
             return message
         return super().default(obj)


### PR DESCRIPTION
This is a PR opened by AI tool [SWE Agent](https://github.com/princeton-nlp/SWE-agent/) to close [#1](https://github.com/SWE-agent/django/issues/1) (Messages framework incorrectly serializes/deserializes extra_tags when it's an empty string).

Closes #1.

<details>
<summary>Thought process ('trajectory') of SWE-agent (click to expand)</summary>

**🧑‍🚒 Response (0)**: 
First, I'll list the files in the current directory to understand the structure of the Django repository and locate the relevant files for the messages framework.
```
ls -F
```
**👀‍ Observation (0)**:
```
AUTHORS
CONTRIBUTING.rst
Gruntfile.js
INSTALL
LICENSE
LICENSE.python
MANIFEST.in
README.rst
django/
docs/
extras/
js_tests/
package.json
pyproject.toml
scripts/
setup.cfg
setup.py
tests/
tox.ini
```

---

**🧑‍🚒 Response (1)**: 
The `django/` directory is likely where the Django framework's core files are located, including the messages framework. Let's navigate into the `django/` directory and list its contents to find the relevant files for the messages framework.
```
ls -F django/
```
**👀‍ Observation (1)**:
```
__init__.py
__main__.py
apps/
conf/
contrib/
core/
db/
dispatch/
forms/
http/
middleware/
shortcuts.py
template/
templatetags/
test/
urls/
utils/
views/
```

---

**🧑‍🚒 Response (2)**: 
The `contrib/` directory often contains additional modules and sub-frameworks, including the messages framework. Let's navigate into the `contrib/` directory and list its contents to find the messages module.
```
ls -F django/contrib/
```
**👀‍ Observation (2)**:
```
__init__.py
admin/
admindocs/
auth/
contenttypes/
flatpages/
gis/
humanize/
messages/
postgres/
redirects/
sessions/
sitemaps/
sites/
staticfiles/
syndication/
```

---

**🧑‍🚒 Response (3)**: 
The `messages/` directory is where the messages framework is located. Let's navigate into the `messages/` directory and list its contents to find the relevant files for serialization and deserialization of messages, specifically looking for `MessageEncoder` and `MessageDecoder`.
```
ls -F django/contrib/messages/
```
**👀‍ Observation (3)**:
```
__init__.py
api.py
apps.py
constants.py
context_processors.py
middleware.py
storage/
utils.py
views.py
```

---

**🧑‍🚒 Response (4)**: 
The `storage/` directory seems like the right place to look for the `MessageEncoder` and `MessageDecoder` classes, as these would be related to how messages are stored. Let's navigate into the `storage/` directory and list its contents to find the relevant files.
```
ls -F django/contrib/messages/storage/
```
**👀‍ Observation (4)**:
```
__init__.py
base.py
cookie.py
fallback.py
session.py
```

---

**🧑‍🚒 Response (5)**: 
The `cookie.py` file is likely where the `MessageEncoder` and `MessageDecoder` classes are defined, based on the issue description. Let's open this file to inspect and potentially modify the serialization and deserialization logic for the `extra_tags` attribute.
```
open django/contrib/messages/storage/cookie.py
```
**👀‍ Observation (5)**:
```
[File: /SWE-agent__django/django/contrib/messages/storage/cookie.py (169 lines total)]
1:import binascii
2:import json
3:
4:from django.conf import settings
5:from django.contrib.messages.storage.base import BaseStorage, Message
6:from django.core import signing
7:from django.http import SimpleCookie
8:from django.utils.safestring import SafeData, mark_safe
9:
10:
11:class MessageEncoder(json.JSONEncoder):
12:    """
13:    Compactly serialize instances of the ``Message`` class as JSON.
14:    """
15:    message_key = '__json_message'
16:
17:    def default(self, obj):
18:        if isinstance(obj, Message):
19:            # Using 0/1 here instead of False/True to produce more compact json
20:            is_safedata = 1 if isinstance(obj.message, SafeData) else 0
21:            message = [self.message_key, is_safedata, obj.level, obj.message]
22:            if obj.extra_tags:
23:                message.append(obj.extra_tags)
24:            return message
25:        return super().default(obj)
26:
27:
28:class MessageDecoder(json.JSONDecoder):
29:    """
30:    Decode JSON that includes serialized ``Message`` instances.
31:    """
32:
33:    def process_messages(self, obj):
34:        if isinstance(obj, list) and obj:
35:            if obj[0] == MessageEncoder.message_key:
36:                if obj[1]:
37:                    obj[3] = mark_safe(obj[3])
38:                return Message(*obj[2:])
39:            return [self.process_messages(item) for item in obj]
40:        if isinstance(obj, dict):
41:            return {key: self.process_messages(value)
42:                    for key, value in obj.items()}
43:        return obj
44:
45:    def decode(self, s, **kwargs):
46:        decoded = super().decode(s, **kwargs)
47:        return self.process_messages(decoded)
48:
49:
50:class MessageSerializer:
51:    def dumps(self, obj):
52:        return json.dumps(
53:            obj,
54:            separators=(',', ':'),
55:            cls=MessageEncoder,
56:        ).encode('latin-1')
57:
58:    def loads(self, data):
59:        return json.loads(data.decode('latin-1'), cls=MessageDecoder)
60:
61:
62:class CookieStorage(BaseStorage):
63:    """
64:    Store messages in a cookie.
65:    """
66:    cookie_name = 'messages'
67:    # uwsgi's default configuration enforces a maximum size of 4kb for all the
68:    # HTTP headers. In order to leave some room for other cookies and headers,
69:    # restrict the session cookie to 1/2 of 4kb. See #18781.
70:    max_cookie_size = 2048
71:    not_finished = '__messagesnotfinished__'
72:    key_salt = 'django.contrib.messages'
73:
74:    def __init__(self, *args, **kwargs):
75:        super().__init__(*args, **kwargs)
76:        self.signer = signing.get_cookie_signer(salt=self.key_salt)
77:
78:    def _get(self, *args, **kwargs):
79:        """
80:        Retrieve a list of messages from the messages cookie. If the
81:        not_finished sentinel value is found at the end of the message list,
82:        remove it and return a result indicating that not all messages were
83:        retrieved by this storage.
84:        """
85:        data = self.request.COOKIES.get(self.cookie_name)
86:        messages = self._decode(data)
87:        all_retrieved = not (messages and messages[-1] == self.not_finished)
88:        if messages and not all_retrieved:
89:            # remove the sentinel value
90:            messages.pop()
91:        return messages, all_retrieved
92:
93:    def _update_cookie(self, encoded_data, response):
94:        """
95:        Either set the cookie with the encoded data if there is any data to
96:        store, or delete the cookie.
97:        """
98:        if encoded_data:
99:            response.set_cookie(
100:                self.cookie_name, encoded_data,
(69 more lines below)
```

---

**🧑‍🚒 Response (6)**: 
The `MessageEncoder` class in the `cookie.py` file is responsible for serializing the `Message` instances. The issue arises because the `extra_tags` attribute is only appended to the serialized message if it is truthy (line 22). This causes an empty string to be omitted, leading to it being interpreted as `None` when deserialized.

To fix this, we need to modify the serialization logic to explicitly check if `extra_tags` is not `None` instead of checking its truthiness. This will ensure that an empty string is serialized and preserved through the serialization and deserialization process.

Let's edit the `MessageEncoder` class to include this change.
```
edit 22:22
            if obj.extra_tags is not None:
                message.append(obj.extra_tags)
end_of_edit
```
**👀‍ Observation (6)**:
```
[File: /SWE-agent__django/django/contrib/messages/storage/cookie.py (170 lines total)]
1:import binascii
2:import json
3:
4:from django.conf import settings
5:from django.contrib.messages.storage.base import BaseStorage, Message
6:from django.core import signing
7:from django.http import SimpleCookie
8:from django.utils.safestring import SafeData, mark_safe
9:
10:
11:class MessageEncoder(json.JSONEncoder):
12:    """
13:    Compactly serialize instances of the ``Message`` class as JSON.
14:    """
15:    message_key = '__json_message'
16:
17:    def default(self, obj):
18:        if isinstance(obj, Message):
19:            # Using 0/1 here instead of False/True to produce more compact json
20:            is_safedata = 1 if isinstance(obj.message, SafeData) else 0
21:            message = [self.message_key, is_safedata, obj.level, obj.message]
22:            if obj.extra_tags is not None:
23:                message.append(obj.extra_tags)
24:                message.append(obj.extra_tags)
25:            return message
26:        return super().default(obj)
27:
28:
29:class MessageDecoder(json.JSONDecoder):
30:    """
31:    Decode JSON that includes serialized ``Message`` instances.
32:    """
33:
34:    def process_messages(self, obj):
35:        if isinstance(obj, list) and obj:
36:            if obj[0] == MessageEncoder.message_key:
37:                if obj[1]:
38:                    obj[3] = mark_safe(obj[3])
39:                return Message(*obj[2:])
40:            return [self.process_messages(item) for item in obj]
41:        if isinstance(obj, dict):
42:            return {key: self.process_messages(value)
43:                    for key, value in obj.items()}
44:        return obj
45:
46:    def decode(self, s, **kwargs):
47:        decoded = super().decode(s, **kwargs)
48:        return self.process_messages(decoded)
49:
50:
51:class MessageSerializer:
52:    def dumps(self, obj):
53:        return json.dumps(
54:            obj,
55:            separators=(',', ':'),
56:            cls=MessageEncoder,
57:        ).encode('latin-1')
58:
59:    def loads(self, data):
60:        return json.loads(data.decode('latin-1'), cls=MessageDecoder)
61:
62:
63:class CookieStorage(BaseStorage):
64:    """
65:    Store messages in a cookie.
66:    """
67:    cookie_name = 'messages'
68:    # uwsgi's default configuration enforces a maximum size of 4kb for all the
69:    # HTTP headers. In order to leave some room for other cookies and headers,
70:    # restrict the session cookie to 1/2 of 4kb. See #18781.
71:    max_cookie_size = 2048
72:    not_finished = '__messagesnotfinished__'
73:    key_salt = 'django.contrib.messages'
74:
75:    def __init__(self, *args, **kwargs):
76:        super().__init__(*args, **kwargs)
77:        self.signer = signing.get_cookie_signer(salt=self.key_salt)
78:
79:    def _get(self, *args, **kwargs):
80:        """
81:        Retrieve a list of messages from the messages cookie. If the
82:        not_finished sentinel value is found at the end of the message list,
83:        remove it and return a result indicating that not all messages were
84:        retrieved by this storage.
85:        """
86:        data = self.request.COOKIES.get(self.cookie_name)
87:        messages = self._decode(data)
88:        all_retrieved = not (messages and messages[-1] == self.not_finished)
89:        if messages and not all_retrieved:
90:            # remove the sentinel value
91:            messages.pop()
92:        return messages, all_retrieved
93:
94:    def _update_cookie(self, encoded_data, response):
95:        """
96:        Either set the cookie with the encoded data if there is any data to
97:        store, or delete the cookie.
98:        """
99:        if encoded_data:
100:            response.set_cookie(
(70 more lines below)
File updated. Please review the changes and make sure they are correct (correct indentation, no duplicate lines, etc). Edit the file again if necessary.
```

---

**🧑‍🚒 Response (7)**: 
It seems there was an accidental duplication of the line appending `extra_tags` in the `MessageEncoder`. I will correct this by removing the duplicate line.

Let's edit the file again to remove the duplicate line.
```
edit 24:24
end_of_edit
```
**👀‍ Observation (7)**:
```
[File: /SWE-agent__django/django/contrib/messages/storage/cookie.py (169 lines total)]
1:import binascii
2:import json
3:
4:from django.conf import settings
5:from django.contrib.messages.storage.base import BaseStorage, Message
6:from django.core import signing
7:from django.http import SimpleCookie
8:from django.utils.safestring import SafeData, mark_safe
9:
10:
11:class MessageEncoder(json.JSONEncoder):
12:    """
13:    Compactly serialize instances of the ``Message`` class as JSON.
14:    """
15:    message_key = '__json_message'
16:
17:    def default(self, obj):
18:        if isinstance(obj, Message):
19:            # Using 0/1 here instead of False/True to produce more compact json
20:            is_safedata = 1 if isinstance(obj.message, SafeData) else 0
21:            message = [self.message_key, is_safedata, obj.level, obj.message]
22:            if obj.extra_tags is not None:
23:                message.append(obj.extra_tags)
24:            return message
25:        return super().default(obj)
26:
27:
28:class MessageDecoder(json.JSONDecoder):
29:    """
30:    Decode JSON that includes serialized ``Message`` instances.
31:    """
32:
33:    def process_messages(self, obj):
34:        if isinstance(obj, list) and obj:
35:            if obj[0] == MessageEncoder.message_key:
36:                if obj[1]:
37:                    obj[3] = mark_safe(obj[3])
38:                return Message(*obj[2:])
39:            return [self.process_messages(item) for item in obj]
40:        if isinstance(obj, dict):
41:            return {key: self.process_messages(value)
42:                    for key, value in obj.items()}
43:        return obj
44:
45:    def decode(self, s, **kwargs):
46:        decoded = super().decode(s, **kwargs)
47:        return self.process_messages(decoded)
48:
49:
50:class MessageSerializer:
51:    def dumps(self, obj):
52:        return json.dumps(
53:            obj,
54:            separators=(',', ':'),
55:            cls=MessageEncoder,
56:        ).encode('latin-1')
57:
58:    def loads(self, data):
59:        return json.loads(data.decode('latin-1'), cls=MessageDecoder)
60:
61:
62:class CookieStorage(BaseStorage):
63:    """
64:    Store messages in a cookie.
65:    """
66:    cookie_name = 'messages'
67:    # uwsgi's default configuration enforces a maximum size of 4kb for all the
68:    # HTTP headers. In order to leave some room for other cookies and headers,
69:    # restrict the session cookie to 1/2 of 4kb. See #18781.
70:    max_cookie_size = 2048
71:    not_finished = '__messagesnotfinished__'
72:    key_salt = 'django.contrib.messages'
73:
74:    def __init__(self, *args, **kwargs):
75:        super().__init__(*args, **kwargs)
76:        self.signer = signing.get_cookie_signer(salt=self.key_salt)
77:
78:    def _get(self, *args, **kwargs):
79:        """
80:        Retrieve a list of messages from the messages cookie. If the
81:        not_finished sentinel value is found at the end of the message list,
82:        remove it and return a result indicating that not all messages were
83:        retrieved by this storage.
84:        """
85:        data = self.request.COOKIES.get(self.cookie_name)
86:        messages = self._decode(data)
87:        all_retrieved = not (messages and messages[-1] == self.not_finished)
88:        if messages and not all_retrieved:
89:            # remove the sentinel value
90:            messages.pop()
91:        return messages, all_retrieved
92:
93:    def _update_cookie(self, encoded_data, response):
94:        """
95:        Either set the cookie with the encoded data if there is any data to
96:        store, or delete the cookie.
97:        """
98:        if encoded_data:
99:            response.set_cookie(
100:                self.cookie_name, encoded_data,
(69 more lines below)
File updated. Please review the changes and make sure they are correct (correct indentation, no duplicate lines, etc). Edit the file again if necessary.
```

---

**🧑‍🚒 Response (8)**: 
The duplicate line has been successfully removed from the `MessageEncoder` class. The serialization now correctly handles the `extra_tags` attribute, ensuring it is preserved even if it's an empty string.

To confirm that the fix works as intended, we should replicate the bug using a script and then verify that the issue is resolved with the new changes. Let's create a new Python script named `test_message_serialization.py` to test the serialization and deserialization process.
```
create test_message_serialization.py
```
**👀‍ Observation (8)**:
```
[File: /SWE-agent__django/test_message_serialization.py (1 lines total)]
1:
```

---

**🧑‍🚒 Response (9)**: 
Now, let's write the test script that replicates the bug as described in the issue. This script will serialize and deserialize a message with `extra_tags` set to an empty string and check if the deserialized `extra_tags` is still an empty string.

```
edit 1:1
from django.conf import settings
settings.configure()  # Just to allow the following import
from django.contrib.messages.storage.base import Message
from django.contrib.messages.storage.cookie import MessageEncoder, MessageDecoder

original_message = Message(10, "Here is a message", extra_tags="")
encoded_message = MessageEncoder().encode(original_message)
decoded_message = MessageDecoder().decode(encoded_message)

print("Original extra_tags:", original_message.extra_tags)
print("Decoded extra_tags:", decoded_message.extra_tags)
end_of_edit
```
**👀‍ Observation (9)**:
```
[File: /SWE-agent__django/test_message_serialization.py (11 lines total)]
1:from django.conf import settings
2:settings.configure()  # Just to allow the following import
3:from django.contrib.messages.storage.base import Message
4:from django.contrib.messages.storage.cookie import MessageEncoder, MessageDecoder
5:
6:original_message = Message(10, "Here is a message", extra_tags="")
7:encoded_message = MessageEncoder().encode(original_message)
8:decoded_message = MessageDecoder().decode(encoded_message)
9:
10:print("Original extra_tags:", original_message.extra_tags)
11:print("Decoded extra_tags:", decoded_message.extra_tags)
File updated. Please review the changes and make sure they are correct (correct indentation, no duplicate lines, etc). Edit the file again if necessary.
```

---

**🧑‍🚒 Response (10)**: 
The test script has been successfully created and is ready to run. This script will help us verify if the serialization and deserialization process now correctly handles the `extra_tags` attribute when it's an empty string.

Let's run the script to see the output and confirm that the issue has been resolved.
```
python test_message_serialization.py
```
**👀‍ Observation (10)**:
```
Traceback (most recent call last):
  File "/SWE-agent__django/test_message_serialization.py", line 1, in <module>
    from django.conf import settings
  File "/SWE-agent__django/django/conf/__init__.py", line 19, in <module>
    from django.utils.deprecation import RemovedInDjango50Warning
  File "/SWE-agent__django/django/utils/deprecation.py", line 5, in <module>
    from asgiref.sync import sync_to_async
ModuleNotFoundError: No module named 'asgiref'
```

---

**🧑‍🚒 Response (11)**: 
It appears that the `asgiref` module is missing, which is required by Django. We need to ensure that all dependencies are installed to run the test script successfully. Let's install the necessary dependencies by setting up the Django project from the source.

First, I'll navigate to the root directory of the Django project to locate the setup file and install the project along with its dependencies.
```
cd django/
```
**👀‍ Observation (11)**:
```

```

---

**🧑‍🚒 Response (12)**: 
Now that we are in the Django directory, let's look for the `setup.py` file to install Django and its dependencies. This will ensure that all necessary modules, including `asgiref`, are available.
```
ls -F
```
**👀‍ Observation (12)**:
```
__init__.py
__main__.py
__pycache__/
apps/
conf/
contrib/
core/
db/
dispatch/
forms/
http/
middleware/
shortcuts.py
template/
templatetags/
test/
urls/
utils/
views/
```

---

**🧑‍🚒 Response (13)**: 
It seems I made an error in navigating to the correct directory for the Django setup file. Let's move up one directory level to the root of the Django repository where the `setup.py` file should be located.
```
cd ..
```
**👀‍ Observation (13)**:
```

```

---

**🧑‍🚒 Response (14)**: 
Now that we're back in the root directory of the Django repository, let's list the files again to locate the `setup.py` file, which is necessary for installing Django and its dependencies.
```
ls -F
```
**👀‍ Observation (14)**:
```
AUTHORS
CONTRIBUTING.rst
Gruntfile.js
INSTALL
LICENSE
LICENSE.python
MANIFEST.in
README.rst
django/
docs/
extras/
js_tests/
package.json
pyproject.toml
scripts/
setup.cfg
setup.py
test_message_serialization.py
tests/
tox.ini
```

---

**🧑‍🚒 Response (15)**: 
The `setup.py` file is present in the current directory. Let's use this file to install Django along with its dependencies. This should resolve the missing module issue and allow us to run the test script successfully.
```
pip install -e .
```
**👀‍ Observation (15)**:
```
Obtaining file:///SWE-agent__django
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Checking if build backend supports build_editable: started
  Checking if build backend supports build_editable: finished with status 'done'
  Getting requirements to build editable: started
  Getting requirements to build editable: finished with status 'done'
  Preparing editable metadata (pyproject.toml): started
  Preparing editable metadata (pyproject.toml): finished with status 'done'
Collecting asgiref>=3.4.1 (from Django==4.1.dev20220122153814)
  Downloading asgiref-3.8.1-py3-none-any.whl.metadata (9.3 kB)
Collecting sqlparse>=0.2.2 (from Django==4.1.dev20220122153814)
  Downloading sqlparse-0.5.0-py3-none-any.whl.metadata (3.9 kB)
Requirement already satisfied: typing-extensions>=4 in /root/miniconda3/lib/python3.9/site-packages (from asgiref>=3.4.1->Django==4.1.dev20220122153814) (4.12.2)
Downloading asgiref-3.8.1-py3-none-any.whl (23 kB)
Downloading sqlparse-0.5.0-py3-none-any.whl (43 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 44.0/44.0 kB 8.4 MB/s eta 0:00:00
Building wheels for collected packages: Django
  Building editable for Django (pyproject.toml): started
  Building editable for Django (pyproject.toml): finished with status 'done'
  Created wheel for Django: filename=Django-4.1.dev20220122153814-0.editable-py3-none-any.whl size=26913 sha256=5afbfc6f14f5cdaeb5ff8400865665513df6e7042e1521be282d715daac4da61
  Stored in directory: /tmp/pip-ephem-wheel-cache-ureitekx/wheels/7f/01/52/7bd8d84a1469c892b7d264fb532775ee6e1890f1b652b5e1c4
Successfully built Django
Installing collected packages: sqlparse, asgiref, Django
Successfully installed Django-4.1.dev20220122153814 asgiref-3.8.1 sqlparse-0.5.0
WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv
```

---

**🧑‍🚒 Response (16)**: 
Django and its dependencies, including `asgiref`, have been successfully installed. We can now rerun the test script `test_message_serialization.py` to verify that the serialization and deserialization process handles the `extra_tags` attribute correctly after our fix.
```
python test_message_serialization.py
```
**👀‍ Observation (16)**:
```
Original extra_tags: 
Decoded extra_tags:
```

---

**🧑‍🚒 Response (17)**: 
The test script output indicates that both the original and decoded `extra_tags` are empty strings, which is the expected behavior after the fix. This confirms that the issue with `extra_tags` being incorrectly serialized/deserialized as `None` when it should be an empty string has been resolved.

Since the fix has been verified, we can now clean up by removing the test script, as it is no longer needed.
```
rm test_message_serialization.py
```
**👀‍ Observation (17)**:
```

```

---

**🧑‍🚒 Response (18)**: 
It appears there was a mistake in updating the interface about the current open file. The `test_message_serialization.py` file should have been removed. Let's proceed to submit the changes to the code base since the issue has been resolved and verified.

```
submit
```
**👀‍ Observation (18)**:
```
diff --git a/django/contrib/messages/storage/cookie.py b/django/contrib/messages/storage/cookie.py
index 1d390c7..e48d4ed 100644
--- a/django/contrib/messages/storage/cookie.py
+++ b/django/contrib/messages/storage/cookie.py
@@ -19,7 +19,7 @@ class MessageEncoder(json.JSONEncoder):
             # Using 0/1 here instead of False/True to produce more compact json
             is_safedata = 1 if isinstance(obj.message, SafeData) else 0
             message = [self.message_key, is_safedata, obj.level, obj.message]
-            if obj.extra_tags:
+            if obj.extra_tags is not None:
                 message.append(obj.extra_tags)
             return message
         return super().default(obj)
```
</details>