### PR TITLE
SWE-agent[bot] PR to fix: Messages framework incorrectly serializes/deserializes extra_tags when it's an empty string

### DIFF
--- a/django/contrib/messages/storage/cookie.py
+++ b/django/contrib/messages/storage/cookie.py
@@ -18,9 +18,7 @@ class MessageEncoder(json.JSONEncoder):
         if isinstance(obj, Message):
             # Using 0/1 here instead of False/True to produce more compact json
             is_safedata = 1 if isinstance(obj.message, SafeData) else 0
-            message = [self.message_key, is_safedata, obj.level, obj.message]
-            if obj.extra_tags:
-                message.append(obj.extra_tags)
+            message = [self.message_key, is_safedata, obj.level, obj.message, obj.extra_tags or None]
             return message
         return super().default(obj)
 
@@ -35,7 +33,7 @@ class MessageDecoder(json.JSONDecoder):
             if obj[0] == MessageEncoder.message_key:
                 if obj[1]:
                     obj[3] = mark_safe(obj[3])
-                return Message(*obj[2:])
+                return Message(obj[2], obj[3], extra_tags=obj[4] if obj[4] is not None else "")
             return [self.process_messages(item) for item in obj]
         if isinstance(obj, dict):
             return {key: self.process_messages(value)


### PR DESCRIPTION
This is a PR opened by AI tool [SWE Agent](https://github.com/princeton-nlp/SWE-agent/) to close [#1](https://github.com/swe-agent/django/issues/1) (Messages framework incorrectly serializes/deserializes extra_tags when it's an empty string).

Closes #1.

<details>
<summary>Thought process ('trajectory') of SWE-agent (click to expand)</summary>

**Action (0)**:
```
create reproduce_bug.py
```
**👀 Observation (0)**:
```
[File: /swe-agent__django/reproduce_bug.py (1 lines total)]
1:
```
**️🧑‍🚒 Response (0)**:
First, let's start by reproducing the issue described. We'll create a new Python script named `reproduce_bug.py` and write the provided code snippet into it to verify the behavior of the serialization and deserialization process.
```
create reproduce_bug.py
```
**🧠 State (0)**:
```
{"open_file": "n/a", "working_dir": "/swe-agent__django"}
```
**💡 Thought (0)**:
First, let's start by reproducing the issue described. We'll create a new Python script named `reproduce_bug.py` and write the provided code snippet into it to verify the behavior of the serialization and deserialization process.

---

**Action (1)**:
```
edit 1:1
from django.conf import settings
settings.configure()  # Just to allow the following import
from django.contrib.messages.storage.base import Message
from django.contrib.messages.storage.cookie import MessageEncoder, MessageDecoder

original_message = Message(10, "Here is a message", extra_tags="")
encoded_message = MessageEncoder().encode(original_message)
decoded_message = MessageDecoder().decode(encoded_message)

print("Original extra_tags empty string:", original_message.extra_tags == "")
print("Decoded extra_tags is None:", decoded_message.extra_tags is None)
end_of_edit
```
**👀 Observation (1)**:
```
[File: /swe-agent__django/reproduce_bug.py (11 lines total)]
1:from django.conf import settings
2:settings.configure()  # Just to allow the following import
3:from django.contrib.messages.storage.base import Message
4:from django.contrib.messages.storage.cookie import MessageEncoder, MessageDecoder
5:
6:original_message = Message(10, "Here is a message", extra_tags="")
7:encoded_message = MessageEncoder().encode(original_message)
8:decoded_message = MessageDecoder().decode(encoded_message)
9:
10:print("Original extra_tags empty string:", original_message.extra_tags == "")
11:print("Decoded extra_tags is None:", decoded_message.extra_tags is None)
File updated. Please review the changes and make sure they are correct (correct indentation, no duplicate lines, etc). Edit the file again if necessary.
```
**️🧑‍🚒 Response (1)**:
Now let's paste in the example code from the issue to reproduce the bug.
```
edit 1:1
from django.conf import settings
settings.configure()  # Just to allow the following import
from django.contrib.messages.storage.base import Message
from django.contrib.messages.storage.cookie import MessageEncoder, MessageDecoder

original_message = Message(10, "Here is a message", extra_tags="")
encoded_message = MessageEncoder().encode(original_message)
decoded_message = MessageDecoder().decode(encoded_message)

print("Original extra_tags empty string:", original_message.extra_tags == "")
print("Decoded extra_tags is None:", decoded_message.extra_tags is None)
end_of_edit
```
**🧠 State (1)**:
```
{"open_file": "/swe-agent__django/reproduce_bug.py", "working_dir": "/swe-agent__django"}
```
**💡 Thought (1)**:
Now let's paste in the example code from the issue to reproduce the bug.

---

**Action (2)**:
```
python reproduce_bug.py
```
**👀 Observation (2)**:
```
Original extra_tags empty string: True
Decoded extra_tags is None: True
```
**️🧑‍🚒 Response (2)**:
Let's run the script to see if we can reproduce the issue as described, where the `extra_tags` attribute changes from an empty string to `None` after serialization and deserialization.
```
python reproduce_bug.py
```
**🧠 State (2)**:
```
{"open_file": "/swe-agent__django/reproduce_bug.py", "working_dir": "/swe-agent__django"}
```
**💡 Thought (2)**:
Let's run the script to see if we can reproduce the issue as described, where the `extra_tags` attribute changes from an empty string to `None` after serialization and deserialization.

---

**Action (3)**:
```
find_file "cookie.py" django
```
**👀 Observation (3)**:
```
Found 2 matches for "cookie.py" in /swe-agent__django/django:
/swe-agent__django/django/contrib/messages/storage/cookie.py
/swe-agent__django/django/http/cookie.py
```
**️🧑‍🚒 Response (3)**:
We have successfully reproduced the issue where the `extra_tags` attribute changes from an empty string to `None` after serialization and deserialization. The next step is to locate and examine the relevant code in the `MessageEncoder` and `MessageDecoder` classes to identify and fix the issue.

Let's start by finding the file where these classes are defined. We'll search for the file in the `django` directory.
```
find_file "cookie.py" django
```
**🧠 State (3)**:
```
{"open_file": "/swe-agent__django/reproduce_bug.py", "working_dir": "/swe-agent__django"}
```
**💡 Thought (3)**:
We have successfully reproduced the issue where the `extra_tags` attribute changes from an empty string to `None` after serialization and deserialization. The next step is to locate and examine the relevant code in the `MessageEncoder` and `MessageDecoder` classes to identify and fix the issue.

Let's start by finding the file where these classes are defined. We'll search for the file in the `django` directory.

---

**Action (4)**:
```
open django/contrib/messages/storage/cookie.py
```
**👀 Observation (4)**:
```
[File: /swe-agent__django/django/contrib/messages/storage/cookie.py (169 lines total)]
1:import binascii
2:import json
3:
4:from django.conf import settings
5:from django.contrib.messages.storage.base import BaseStorage, Message
6:from django.core import signing
7:from django.http import SimpleCookie
8:from django.utils.safestring import SafeData, mark_safe
9:
10:
11:class MessageEncoder(json.JSONEncoder):
12:    """
13:    Compactly serialize instances of the ``Message`` class as JSON.
14:    """
15:    message_key = '__json_message'
16:
17:    def default(self, obj):
18:        if isinstance(obj, Message):
19:            # Using 0/1 here instead of False/True to produce more compact json
20:            is_safedata = 1 if isinstance(obj.message, SafeData) else 0
21:            message = [self.message_key, is_safedata, obj.level, obj.message]
22:            if obj.extra_tags:
23:                message.append(obj.extra_tags)
24:            return message
25:        return super().default(obj)
26:
27:
28:class MessageDecoder(json.JSONDecoder):
29:    """
30:    Decode JSON that includes serialized ``Message`` instances.
31:    """
32:
33:    def process_messages(self, obj):
34:        if isinstance(obj, list) and obj:
35:            if obj[0] == MessageEncoder.message_key:
36:                if obj[1]:
37:                    obj[3] = mark_safe(obj[3])
38:                return Message(*obj[2:])
39:            return [self.process_messages(item) for item in obj]
40:        if isinstance(obj, dict):
41:            return {key: self.process_messages(value)
42:                    for key, value in obj.items()}
43:        return obj
44:
45:    def decode(self, s, **kwargs):
46:        decoded = super().decode(s, **kwargs)
47:        return self.process_messages(decoded)
48:
49:
50:class MessageSerializer:
51:    def dumps(self, obj):
52:        return json.dumps(
53:            obj,
54:            separators=(',', ':'),
55:            cls=MessageEncoder,
56:        ).encode('latin-1')
57:
58:    def loads(self, data):
59:        return json.loads(data.decode('latin-1'), cls=MessageDecoder)
60:
61:
62:class CookieStorage(BaseStorage):
63:    """
64:    Store messages in a cookie.
65:    """
66:    cookie_name = 'messages'
67:    # uwsgi's default configuration enforces a maximum size of 4kb for all the
68:    # HTTP headers. In order to leave some room for other cookies and headers,
69:    # restrict the session cookie to 1/2 of 4kb. See #18781.
70:    max_cookie_size = 2048
71:    not_finished = '__messagesnotfinished__'
72:    key_salt = 'django.contrib.messages'
73:
74:    def __init__(self, *args, **kwargs):
75:        super().__init__(*args, **kwargs)
76:        self.signer = signing.get_cookie_signer(salt=self.key_salt)
77:
78:    def _get(self, *args, **kwargs):
79:        """
80:        Retrieve a list of messages from the messages cookie. If the
81:        not_finished sentinel value is found at the end of the message list,
82:        remove it and return a result indicating that not all messages were
83:        retrieved by this storage.
84:        """
85:        data = self.request.COOKIES.get(self.cookie_name)
86:        messages = self._decode(data)
87:        all_retrieved = not (messages and messages[-1] == self.not_finished)
88:        if messages and not all_retrieved:
89:            # remove the sentinel value
90:            messages.pop()
91:        return messages, all_retrieved
92:
93:    def _update_cookie(self, encoded_data, response):
94:        """
95:        Either set the cookie with the encoded data if there is any data to
96:        store, or delete the cookie.
97:        """
98:        if encoded_data:
99:            response.set_cookie(
100:                self.cookie_name, encoded_data,
(69 more lines below)
```
**️🧑‍🚒 Response (4)**:
The relevant file for our issue appears to be `/swe-agent__django/django/contrib/messages/storage/cookie.py` since it pertains to message storage, which is where the `MessageEncoder` and `MessageDecoder` classes are likely defined.

Let's open this file to inspect the implementation of these classes and identify the problematic code.
```
open django/contrib/messages/storage/cookie.py
```
**🧠 State (4)**:
```
{"open_file": "/swe-agent__django/reproduce_bug.py", "working_dir": "/swe-agent__django"}
```
**💡 Thought (4)**:
The relevant file for our issue appears to be `/swe-agent__django/django/contrib/messages/storage/cookie.py` since it pertains to message storage, which is where the `MessageEncoder` and `MessageDecoder` classes are likely defined.

Let's open this file to inspect the implementation of these classes and identify the problematic code.

---

**Action (5)**:
```
edit 22:24
            message = [self.message_key, is_safedata, obj.level, obj.message, obj.extra_tags]
end_of_edit
```
**👀 Observation (5)**:
```
[File: /swe-agent__django/django/contrib/messages/storage/cookie.py (167 lines total)]
1:import binascii
2:import json
3:
4:from django.conf import settings
5:from django.contrib.messages.storage.base import BaseStorage, Message
6:from django.core import signing
7:from django.http import SimpleCookie
8:from django.utils.safestring import SafeData, mark_safe
9:
10:
11:class MessageEncoder(json.JSONEncoder):
12:    """
13:    Compactly serialize instances of the ``Message`` class as JSON.
14:    """
15:    message_key = '__json_message'
16:
17:    def default(self, obj):
18:        if isinstance(obj, Message):
19:            # Using 0/1 here instead of False/True to produce more compact json
20:            is_safedata = 1 if isinstance(obj.message, SafeData) else 0
21:            message = [self.message_key, is_safedata, obj.level, obj.message]
22:            message = [self.message_key, is_safedata, obj.level, obj.message, obj.extra_tags]
23:        return super().default(obj)
24:
25:
26:class MessageDecoder(json.JSONDecoder):
27:    """
28:    Decode JSON that includes serialized ``Message`` instances.
29:    """
30:
31:    def process_messages(self, obj):
32:        if isinstance(obj, list) and obj:
33:            if obj[0] == MessageEncoder.message_key:
34:                if obj[1]:
35:                    obj[3] = mark_safe(obj[3])
36:                return Message(*obj[2:])
37:            return [self.process_messages(item) for item in obj]
38:        if isinstance(obj, dict):
39:            return {key: self.process_messages(value)
40:                    for key, value in obj.items()}
41:        return obj
42:
43:    def decode(self, s, **kwargs):
44:        decoded = super().decode(s, **kwargs)
45:        return self.process_messages(decoded)
46:
47:
48:class MessageSerializer:
49:    def dumps(self, obj):
50:        return json.dumps(
51:            obj,
52:            separators=(',', ':'),
53:            cls=MessageEncoder,
54:        ).encode('latin-1')
55:
56:    def loads(self, data):
57:        return json.loads(data.decode('latin-1'), cls=MessageDecoder)
58:
59:
60:class CookieStorage(BaseStorage):
61:    """
62:    Store messages in a cookie.
63:    """
64:    cookie_name = 'messages'
65:    # uwsgi's default configuration enforces a maximum size of 4kb for all the
66:    # HTTP headers. In order to leave some room for other cookies and headers,
67:    # restrict the session cookie to 1/2 of 4kb. See #18781.
68:    max_cookie_size = 2048
69:    not_finished = '__messagesnotfinished__'
70:    key_salt = 'django.contrib.messages'
71:
72:    def __init__(self, *args, **kwargs):
73:        super().__init__(*args, **kwargs)
74:        self.signer = signing.get_cookie_signer(salt=self.key_salt)
75:
76:    def _get(self, *args, **kwargs):
77:        """
78:        Retrieve a list of messages from the messages cookie. If the
79:        not_finished sentinel value is found at the end of the message list,
80:        remove it and return a result indicating that not all messages were
81:        retrieved by this storage.
82:        """
83:        data = self.request.COOKIES.get(self.cookie_name)
84:        messages = self._decode(data)
85:        all_retrieved = not (messages and messages[-1] == self.not_finished)
86:        if messages and not all_retrieved:
87:            # remove the sentinel value
88:            messages.pop()
89:        return messages, all_retrieved
90:
91:    def _update_cookie(self, encoded_data, response):
92:        """
93:        Either set the cookie with the encoded data if there is any data to
94:        store, or delete the cookie.
95:        """
96:        if encoded_data:
97:            response.set_cookie(
98:                self.cookie_name, encoded_data,
99:                domain=settings.SESSION_COOKIE_DOMAIN,
100:                secure=settings.SESSION_COOKIE_SECURE or None,
(67 more lines below)
File updated. Please review the changes and make sure they are correct (correct indentation, no duplicate lines, etc). Edit the file again if necessary.
```
**️🧑‍🚒 Response (5)**:
We have the `cookie.py` file open, which contains the `MessageEncoder` and `MessageDecoder` classes. The issue seems to be related to how `extra_tags` is handled during serialization and deserialization.

In the `MessageEncoder` class, the `extra_tags` is only appended to the message if it is truthy (line 22). This means that an empty string, which is falsy, is not included in the serialized data, leading to it being absent and thus interpreted as `None` when deserialized.

To fix this, we need to modify the `MessageEncoder` to always include `extra_tags`, regardless of its truthiness. Let's make the necessary edit to the code.
```
edit 22:24
            message = [self.message_key, is_safedata, obj.level, obj.message, obj.extra_tags]
end_of_edit
```
**🧠 State (5)**:
```
{"open_file": "/swe-agent__django/django/contrib/messages/storage/cookie.py", "working_dir": "/swe-agent__django"}
```
**💡 Thought (5)**:
We have the `cookie.py` file open, which contains the `MessageEncoder` and `MessageDecoder` classes. The issue seems to be related to how `extra_tags` is handled during serialization and deserialization.

In the `MessageEncoder` class, the `extra_tags` is only appended to the message if it is truthy (line 22). This means that an empty string, which is falsy, is not included in the serialized data, leading to it being absent and thus interpreted as `None` when deserialized.

To fix this, we need to modify the `MessageEncoder` to always include `extra_tags`, regardless of its truthiness. Let's make the necessary edit to the code.

---

**Action (6)**:
```
python reproduce_bug.py
```
**👀 Observation (6)**:
```
Traceback (most recent call last):
  File "/swe-agent__django/reproduce_bug.py", line 7, in <module>
    encoded_message = MessageEncoder().encode(original_message)
  File "/root/miniconda3/envs/swe-agent__django__7c4f396/lib/python3.9/json/encoder.py", line 199, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/root/miniconda3/envs/swe-agent__django__7c4f396/lib/python3.9/json/encoder.py", line 257, in iterencode
    return _iterencode(o, 0)
  File "/swe-agent__django/django/contrib/messages/storage/cookie.py", line 23, in default
    return super().default(obj)
  File "/root/miniconda3/envs/swe-agent__django__7c4f396/lib/python3.9/json/encoder.py", line 179, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
TypeError: Object of type Message is not JSON serializable
```
**️🧑‍🚒 Response (6)**:
The edit to always include `extra_tags` in the serialized data has been successfully applied. Now, let's rerun the `reproduce_bug.py` script to verify that the issue has been resolved and that `extra_tags` remains an empty string after serialization and deserialization, rather than turning into `None`.
```
python reproduce_bug.py
```
**🧠 State (6)**:
```
{"open_file": "/swe-agent__django/django/contrib/messages/storage/cookie.py", "working_dir": "/swe-agent__django"}
```
**💡 Thought (6)**:
The edit to always include `extra_tags` in the serialized data has been successfully applied. Now, let's rerun the `reproduce_bug.py` script to verify that the issue has been resolved and that `extra_tags` remains an empty string after serialization and deserialization, rather than turning into `None`.

---

**Action (7)**:
```
open django/contrib/messages/storage/cookie.py
```
**👀 Observation (7)**:
```
[File: /swe-agent__django/django/contrib/messages/storage/cookie.py (167 lines total)]
1:import binascii
2:import json
3:
4:from django.conf import settings
5:from django.contrib.messages.storage.base import BaseStorage, Message
6:from django.core import signing
7:from django.http import SimpleCookie
8:from django.utils.safestring import SafeData, mark_safe
9:
10:
11:class MessageEncoder(json.JSONEncoder):
12:    """
13:    Compactly serialize instances of the ``Message`` class as JSON.
14:    """
15:    message_key = '__json_message'
16:
17:    def default(self, obj):
18:        if isinstance(obj, Message):
19:            # Using 0/1 here instead of False/True to produce more compact json
20:            is_safedata = 1 if isinstance(obj.message, SafeData) else 0
21:            message = [self.message_key, is_safedata, obj.level, obj.message]
22:            message = [self.message_key, is_safedata, obj.level, obj.message, obj.extra_tags]
23:        return super().default(obj)
24:
25:
26:class MessageDecoder(json.JSONDecoder):
27:    """
28:    Decode JSON that includes serialized ``Message`` instances.
29:    """
30:
31:    def process_messages(self, obj):
32:        if isinstance(obj, list) and obj:
33:            if obj[0] == MessageEncoder.message_key:
34:                if obj[1]:
35:                    obj[3] = mark_safe(obj[3])
36:                return Message(*obj[2:])
37:            return [self.process_messages(item) for item in obj]
38:        if isinstance(obj, dict):
39:            return {key: self.process_messages(value)
40:                    for key, value in obj.items()}
41:        return obj
42:
43:    def decode(self, s, **kwargs):
44:        decoded = super().decode(s, **kwargs)
45:        return self.process_messages(decoded)
46:
47:
48:class MessageSerializer:
49:    def dumps(self, obj):
50:        return json.dumps(
51:            obj,
52:            separators=(',', ':'),
53:            cls=MessageEncoder,
54:        ).encode('latin-1')
55:
56:    def loads(self, data):
57:        return json.loads(data.decode('latin-1'), cls=MessageDecoder)
58:
59:
60:class CookieStorage(BaseStorage):
61:    """
62:    Store messages in a cookie.
63:    """
64:    cookie_name = 'messages'
65:    # uwsgi's default configuration enforces a maximum size of 4kb for all the
66:    # HTTP headers. In order to leave some room for other cookies and headers,
67:    # restrict the session cookie to 1/2 of 4kb. See #18781.
68:    max_cookie_size = 2048
69:    not_finished = '__messagesnotfinished__'
70:    key_salt = 'django.contrib.messages'
71:
72:    def __init__(self, *args, **kwargs):
73:        super().__init__(*args, **kwargs)
74:        self.signer = signing.get_cookie_signer(salt=self.key_salt)
75:
76:    def _get(self, *args, **kwargs):
77:        """
78:        Retrieve a list of messages from the messages cookie. If the
79:        not_finished sentinel value is found at the end of the message list,
80:        remove it and return a result indicating that not all messages were
81:        retrieved by this storage.
82:        """
83:        data = self.request.COOKIES.get(self.cookie_name)
84:        messages = self._decode(data)
85:        all_retrieved = not (messages and messages[-1] == self.not_finished)
86:        if messages and not all_retrieved:
87:            # remove the sentinel value
88:            messages.pop()
89:        return messages, all_retrieved
90:
91:    def _update_cookie(self, encoded_data, response):
92:        """
93:        Either set the cookie with the encoded data if there is any data to
94:        store, or delete the cookie.
95:        """
96:        if encoded_data:
97:            response.set_cookie(
98:                self.cookie_name, encoded_data,
99:                domain=settings.SESSION_COOKIE_DOMAIN,
100:                secure=settings.SESSION_COOKIE_SECURE or None,
(67 more lines below)
```
**️🧑‍🚒 Response (7)**:
It appears that the modification to the `MessageEncoder` class has introduced an error in the serialization process. The error message indicates that the `Message` object is not being serialized correctly. This suggests that the structure of the serialized data might be incorrect or incomplete.

Let's revisit the `MessageEncoder` class and adjust the serialization logic to ensure that all necessary components of the `Message` object are correctly handled. We need to ensure that the `Message` object is fully and correctly serialized into a JSON-compatible format.

Let's open the `cookie.py` file again to inspect and correct the serialization logic.
```
open django/contrib/messages/storage/cookie.py
```
**🧠 State (7)**:
```
{"open_file": "/swe-agent__django/django/contrib/messages/storage/cookie.py", "working_dir": "/swe-agent__django"}
```
**💡 Thought (7)**:
It appears that the modification to the `MessageEncoder` class has introduced an error in the serialization process. The error message indicates that the `Message` object is not being serialized correctly. This suggests that the structure of the serialized data might be incorrect or incomplete.

Let's revisit the `MessageEncoder` class and adjust the serialization logic to ensure that all necessary components of the `Message` object are correctly handled. We need to ensure that the `Message` object is fully and correctly serialized into a JSON-compatible format.

Let's open the `cookie.py` file again to inspect and correct the serialization logic.

---

**Action (8)**:
```
edit 17:23
    def default(self, obj):
        if isinstance(obj, Message):
            # Using 0/1 here instead of False/True to produce more compact json
            is_safedata = 1 if isinstance(obj.message, SafeData) else 0
            message = [self.message_key, is_safedata, obj.level, obj.message, obj.extra_tags or None]
            return message
        return super().default(obj)
end_of_edit
```
**👀 Observation (8)**:
```
[File: /swe-agent__django/django/contrib/messages/storage/cookie.py (167 lines total)]
1:import binascii
2:import json
3:
4:from django.conf import settings
5:from django.contrib.messages.storage.base import BaseStorage, Message
6:from django.core import signing
7:from django.http import SimpleCookie
8:from django.utils.safestring import SafeData, mark_safe
9:
10:
11:class MessageEncoder(json.JSONEncoder):
12:    """
13:    Compactly serialize instances of the ``Message`` class as JSON.
14:    """
15:    message_key = '__json_message'
16:
17:    def default(self, obj):
18:        if isinstance(obj, Message):
19:            # Using 0/1 here instead of False/True to produce more compact json
20:            is_safedata = 1 if isinstance(obj.message, SafeData) else 0
21:            message = [self.message_key, is_safedata, obj.level, obj.message, obj.extra_tags or None]
22:            return message
23:        return super().default(obj)
24:
25:
26:class MessageDecoder(json.JSONDecoder):
27:    """
28:    Decode JSON that includes serialized ``Message`` instances.
29:    """
30:
31:    def process_messages(self, obj):
32:        if isinstance(obj, list) and obj:
33:            if obj[0] == MessageEncoder.message_key:
34:                if obj[1]:
35:                    obj[3] = mark_safe(obj[3])
36:                return Message(*obj[2:])
37:            return [self.process_messages(item) for item in obj]
38:        if isinstance(obj, dict):
39:            return {key: self.process_messages(value)
40:                    for key, value in obj.items()}
41:        return obj
42:
43:    def decode(self, s, **kwargs):
44:        decoded = super().decode(s, **kwargs)
45:        return self.process_messages(decoded)
46:
47:
48:class MessageSerializer:
49:    def dumps(self, obj):
50:        return json.dumps(
51:            obj,
52:            separators=(',', ':'),
53:            cls=MessageEncoder,
54:        ).encode('latin-1')
55:
56:    def loads(self, data):
57:        return json.loads(data.decode('latin-1'), cls=MessageDecoder)
58:
59:
60:class CookieStorage(BaseStorage):
61:    """
62:    Store messages in a cookie.
63:    """
64:    cookie_name = 'messages'
65:    # uwsgi's default configuration enforces a maximum size of 4kb for all the
66:    # HTTP headers. In order to leave some room for other cookies and headers,
67:    # restrict the session cookie to 1/2 of 4kb. See #18781.
68:    max_cookie_size = 2048
69:    not_finished = '__messagesnotfinished__'
70:    key_salt = 'django.contrib.messages'
71:
72:    def __init__(self, *args, **kwargs):
73:        super().__init__(*args, **kwargs)
74:        self.signer = signing.get_cookie_signer(salt=self.key_salt)
75:
76:    def _get(self, *args, **kwargs):
77:        """
78:        Retrieve a list of messages from the messages cookie. If the
79:        not_finished sentinel value is found at the end of the message list,
80:        remove it and return a result indicating that not all messages were
81:        retrieved by this storage.
82:        """
83:        data = self.request.COOKIES.get(self.cookie_name)
84:        messages = self._decode(data)
85:        all_retrieved = not (messages and messages[-1] == self.not_finished)
86:        if messages and not all_retrieved:
87:            # remove the sentinel value
88:            messages.pop()
89:        return messages, all_retrieved
90:
91:    def _update_cookie(self, encoded_data, response):
92:        """
93:        Either set the cookie with the encoded data if there is any data to
94:        store, or delete the cookie.
95:        """
96:        if encoded_data:
97:            response.set_cookie(
98:                self.cookie_name, encoded_data,
99:                domain=settings.SESSION_COOKIE_DOMAIN,
100:                secure=settings.SESSION_COOKIE_SECURE or None,
(67 more lines below)
File updated. Please review the changes and make sure they are correct (correct indentation, no duplicate lines, etc). Edit the file again if necessary.
```
**️🧑‍🚒 Response (8)**:
The error occurred because the `Message` object was not being serialized properly. The `default` method in the `MessageEncoder` class needs to ensure that all parts of the `Message` object are correctly converted into a JSON-serializable format.

Let's adjust the serialization logic to correctly handle the `Message` object, ensuring that all attributes are included and properly formatted.

```
edit 17:23
    def default(self, obj):
        if isinstance(obj, Message):
            # Using 0/1 here instead of False/True to produce more compact json
            is_safedata = 1 if isinstance(obj.message, SafeData) else 0
            message = [self.message_key, is_safedata, obj.level, obj.message, obj.extra_tags or None]
            return message
        return super().default(obj)
end_of_edit
```
**🧠 State (8)**:
```
{"open_file": "/swe-agent__django/django/contrib/messages/storage/cookie.py", "working_dir": "/swe-agent__django"}
```
**💡 Thought (8)**:
The error occurred because the `Message` object was not being serialized properly. The `default` method in the `MessageEncoder` class needs to ensure that all parts of the `Message` object are correctly converted into a JSON-serializable format.

Let's adjust the serialization logic to correctly handle the `Message` object, ensuring that all attributes are included and properly formatted.

---

**Action (9)**:
```
python reproduce_bug.py
```
**👀 Observation (9)**:
```
Original extra_tags empty string: True
Decoded extra_tags is None: True
```
**️🧑‍🚒 Response (9)**:
The serialization logic has been adjusted to ensure that the `Message` object is correctly handled, including the `extra_tags` attribute. Let's rerun the `reproduce_bug.py` script to verify that the issue has been resolved and that `extra_tags` remains an empty string after serialization and deserialization, rather than turning into `None`.
```
python reproduce_bug.py
```
**🧠 State (9)**:
```
{"open_file": "/swe-agent__django/django/contrib/messages/storage/cookie.py", "working_dir": "/swe-agent__django"}
```
**💡 Thought (9)**:
The serialization logic has been adjusted to ensure that the `Message` object is correctly handled, including the `extra_tags` attribute. Let's rerun the `reproduce_bug.py` script to verify that the issue has been resolved and that `extra_tags` remains an empty string after serialization and deserialization, rather than turning into `None`.

---

**Action (10)**:
```
open django/contrib/messages/storage/cookie.py
```
**👀 Observation (10)**:
```
[File: /swe-agent__django/django/contrib/messages/storage/cookie.py (167 lines total)]
1:import binascii
2:import json
3:
4:from django.conf import settings
5:from django.contrib.messages.storage.base import BaseStorage, Message
6:from django.core import signing
7:from django.http import SimpleCookie
8:from django.utils.safestring import SafeData, mark_safe
9:
10:
11:class MessageEncoder(json.JSONEncoder):
12:    """
13:    Compactly serialize instances of the ``Message`` class as JSON.
14:    """
15:    message_key = '__json_message'
16:
17:    def default(self, obj):
18:        if isinstance(obj, Message):
19:            # Using 0/1 here instead of False/True to produce more compact json
20:            is_safedata = 1 if isinstance(obj.message, SafeData) else 0
21:            message = [self.message_key, is_safedata, obj.level, obj.message, obj.extra_tags or None]
22:            return message
23:        return super().default(obj)
24:
25:
26:class MessageDecoder(json.JSONDecoder):
27:    """
28:    Decode JSON that includes serialized ``Message`` instances.
29:    """
30:
31:    def process_messages(self, obj):
32:        if isinstance(obj, list) and obj:
33:            if obj[0] == MessageEncoder.message_key:
34:                if obj[1]:
35:                    obj[3] = mark_safe(obj[3])
36:                return Message(*obj[2:])
37:            return [self.process_messages(item) for item in obj]
38:        if isinstance(obj, dict):
39:            return {key: self.process_messages(value)
40:                    for key, value in obj.items()}
41:        return obj
42:
43:    def decode(self, s, **kwargs):
44:        decoded = super().decode(s, **kwargs)
45:        return self.process_messages(decoded)
46:
47:
48:class MessageSerializer:
49:    def dumps(self, obj):
50:        return json.dumps(
51:            obj,
52:            separators=(',', ':'),
53:            cls=MessageEncoder,
54:        ).encode('latin-1')
55:
56:    def loads(self, data):
57:        return json.loads(data.decode('latin-1'), cls=MessageDecoder)
58:
59:
60:class CookieStorage(BaseStorage):
61:    """
62:    Store messages in a cookie.
63:    """
64:    cookie_name = 'messages'
65:    # uwsgi's default configuration enforces a maximum size of 4kb for all the
66:    # HTTP headers. In order to leave some room for other cookies and headers,
67:    # restrict the session cookie to 1/2 of 4kb. See #18781.
68:    max_cookie_size = 2048
69:    not_finished = '__messagesnotfinished__'
70:    key_salt = 'django.contrib.messages'
71:
72:    def __init__(self, *args, **kwargs):
73:        super().__init__(*args, **kwargs)
74:        self.signer = signing.get_cookie_signer(salt=self.key_salt)
75:
76:    def _get(self, *args, **kwargs):
77:        """
78:        Retrieve a list of messages from the messages cookie. If the
79:        not_finished sentinel value is found at the end of the message list,
80:        remove it and return a result indicating that not all messages were
81:        retrieved by this storage.
82:        """
83:        data = self.request.COOKIES.get(self.cookie_name)
84:        messages = self._decode(data)
85:        all_retrieved = not (messages and messages[-1] == self.not_finished)
86:        if messages and not all_retrieved:
87:            # remove the sentinel value
88:            messages.pop()
89:        return messages, all_retrieved
90:
91:    def _update_cookie(self, encoded_data, response):
92:        """
93:        Either set the cookie with the encoded data if there is any data to
94:        store, or delete the cookie.
95:        """
96:        if encoded_data:
97:            response.set_cookie(
98:                self.cookie_name, encoded_data,
99:                domain=settings.SESSION_COOKIE_DOMAIN,
100:                secure=settings.SESSION_COOKIE_SECURE or None,
(67 more lines below)
```
**️🧑‍🚒 Response (10)**:
It appears that the issue still persists, as the `extra_tags` is still being decoded as `None` instead of an empty string. This suggests that the problem might also involve the decoding process, not just the encoding.

Let's inspect the `MessageDecoder` class to ensure it correctly handles the `extra_tags` during the decoding process, especially when it's an empty string.

We need to open the `cookie.py` file again to inspect and potentially adjust the decoding logic.
```
open django/contrib/messages/storage/cookie.py
```
**🧠 State (10)**:
```
{"open_file": "/swe-agent__django/django/contrib/messages/storage/cookie.py", "working_dir": "/swe-agent__django"}
```
**💡 Thought (10)**:
It appears that the issue still persists, as the `extra_tags` is still being decoded as `None` instead of an empty string. This suggests that the problem might also involve the decoding process, not just the encoding.

Let's inspect the `MessageDecoder` class to ensure it correctly handles the `extra_tags` during the decoding process, especially when it's an empty string.

We need to open the `cookie.py` file again to inspect and potentially adjust the decoding logic.

---

**Action (11)**:
```
edit 36:36
                return Message(obj[2], obj[3], extra_tags=obj[4] if obj[4] is not None else "")
end_of_edit
```
**👀 Observation (11)**:
```
[File: /swe-agent__django/django/contrib/messages/storage/cookie.py (167 lines total)]
1:import binascii
2:import json
3:
4:from django.conf import settings
5:from django.contrib.messages.storage.base import BaseStorage, Message
6:from django.core import signing
7:from django.http import SimpleCookie
8:from django.utils.safestring import SafeData, mark_safe
9:
10:
11:class MessageEncoder(json.JSONEncoder):
12:    """
13:    Compactly serialize instances of the ``Message`` class as JSON.
14:    """
15:    message_key = '__json_message'
16:
17:    def default(self, obj):
18:        if isinstance(obj, Message):
19:            # Using 0/1 here instead of False/True to produce more compact json
20:            is_safedata = 1 if isinstance(obj.message, SafeData) else 0
21:            message = [self.message_key, is_safedata, obj.level, obj.message, obj.extra_tags or None]
22:            return message
23:        return super().default(obj)
24:
25:
26:class MessageDecoder(json.JSONDecoder):
27:    """
28:    Decode JSON that includes serialized ``Message`` instances.
29:    """
30:
31:    def process_messages(self, obj):
32:        if isinstance(obj, list) and obj:
33:            if obj[0] == MessageEncoder.message_key:
34:                if obj[1]:
35:                    obj[3] = mark_safe(obj[3])
36:                return Message(obj[2], obj[3], extra_tags=obj[4] if obj[4] is not None else "")
37:            return [self.process_messages(item) for item in obj]
38:        if isinstance(obj, dict):
39:            return {key: self.process_messages(value)
40:                    for key, value in obj.items()}
41:        return obj
42:
43:    def decode(self, s, **kwargs):
44:        decoded = super().decode(s, **kwargs)
45:        return self.process_messages(decoded)
46:
47:
48:class MessageSerializer:
49:    def dumps(self, obj):
50:        return json.dumps(
51:            obj,
52:            separators=(',', ':'),
53:            cls=MessageEncoder,
54:        ).encode('latin-1')
55:
56:    def loads(self, data):
57:        return json.loads(data.decode('latin-1'), cls=MessageDecoder)
58:
59:
60:class CookieStorage(BaseStorage):
61:    """
62:    Store messages in a cookie.
63:    """
64:    cookie_name = 'messages'
65:    # uwsgi's default configuration enforces a maximum size of 4kb for all the
66:    # HTTP headers. In order to leave some room for other cookies and headers,
67:    # restrict the session cookie to 1/2 of 4kb. See #18781.
68:    max_cookie_size = 2048
69:    not_finished = '__messagesnotfinished__'
70:    key_salt = 'django.contrib.messages'
71:
72:    def __init__(self, *args, **kwargs):
73:        super().__init__(*args, **kwargs)
74:        self.signer = signing.get_cookie_signer(salt=self.key_salt)
75:
76:    def _get(self, *args, **kwargs):
77:        """
78:        Retrieve a list of messages from the messages cookie. If the
79:        not_finished sentinel value is found at the end of the message list,
80:        remove it and return a result indicating that not all messages were
81:        retrieved by this storage.
82:        """
83:        data = self.request.COOKIES.get(self.cookie_name)
84:        messages = self._decode(data)
85:        all_retrieved = not (messages and messages[-1] == self.not_finished)
86:        if messages and not all_retrieved:
87:            # remove the sentinel value
88:            messages.pop()
89:        return messages, all_retrieved
90:
91:    def _update_cookie(self, encoded_data, response):
92:        """
93:        Either set the cookie with the encoded data if there is any data to
94:        store, or delete the cookie.
95:        """
96:        if encoded_data:
97:            response.set_cookie(
98:                self.cookie_name, encoded_data,
99:                domain=settings.SESSION_COOKIE_DOMAIN,
100:                secure=settings.SESSION_COOKIE_SECURE or None,
(67 more lines below)
File updated. Please review the changes and make sure they are correct (correct indentation, no duplicate lines, etc). Edit the file again if necessary.
```
**️🧑‍🚒 Response (11)**:
The `MessageDecoder` class is responsible for reconstructing the `Message` object from the serialized data. The current implementation in the `process_messages` method (line 36) constructs the `Message` object using the unpacked list, which may not handle `None` values for `extra_tags` correctly when it should be an empty string.

We need to adjust the decoding logic to ensure that `extra_tags` is correctly handled as an empty string when it was originally an empty string before serialization. Let's make the necessary edit to the code.

```
edit 36:36
                return Message(obj[2], obj[3], extra_tags=obj[4] if obj[4] is not None else "")
end_of_edit
```
**🧠 State (11)**:
```
{"open_file": "/swe-agent__django/django/contrib/messages/storage/cookie.py", "working_dir": "/swe-agent__django"}
```
**💡 Thought (11)**:
The `MessageDecoder` class is responsible for reconstructing the `Message` object from the serialized data. The current implementation in the `process_messages` method (line 36) constructs the `Message` object using the unpacked list, which may not handle `None` values for `extra_tags` correctly when it should be an empty string.

We need to adjust the decoding logic to ensure that `extra_tags` is correctly handled as an empty string when it was originally an empty string before serialization. Let's make the necessary edit to the code.

---

**Action (12)**:
```
python reproduce_bug.py
```
**👀 Observation (12)**:
```
Original extra_tags empty string: True
Decoded extra_tags is None: False
```
**️🧑‍🚒 Response (12)**:
The decoding logic has been adjusted to handle `extra_tags` correctly, ensuring that it defaults to an empty string if it was originally an empty string before serialization. Let's rerun the `reproduce_bug.py` script to verify that the issue has been resolved and that `extra_tags` remains an empty string after serialization and deserialization, rather than turning into `None`.
```
python reproduce_bug.py
```
**🧠 State (12)**:
```
{"open_file": "/swe-agent__django/django/contrib/messages/storage/cookie.py", "working_dir": "/swe-agent__django"}
```
**💡 Thought (12)**:
The decoding logic has been adjusted to handle `extra_tags` correctly, ensuring that it defaults to an empty string if it was originally an empty string before serialization. Let's rerun the `reproduce_bug.py` script to verify that the issue has been resolved and that `extra_tags` remains an empty string after serialization and deserialization, rather than turning into `None`.

---

**Action (13)**:
```
rm reproduce_bug.py
```
**👀 Observation (13)**:
```

```
**️🧑‍🚒 Response (13)**:
The output confirms that the issue has been resolved: `extra_tags` now remains an empty string after serialization and deserialization, rather than turning into `None`. This means our changes to the encoding and decoding logic are effective.

Since the bug has been successfully fixed, we can clean up any test scripts or temporary files and then submit our changes to the code base.

Let's remove the `reproduce_bug.py` file since it is no longer needed.
```
rm reproduce_bug.py
```
**🧠 State (13)**:
```
{"open_file": "/swe-agent__django/django/contrib/messages/storage/cookie.py", "working_dir": "/swe-agent__django"}
```
**💡 Thought (13)**:
The output confirms that the issue has been resolved: `extra_tags` now remains an empty string after serialization and deserialization, rather than turning into `None`. This means our changes to the encoding and decoding logic are effective.

Since the bug has been successfully fixed, we can clean up any test scripts or temporary files and then submit our changes to the code base.

Let's remove the `reproduce_bug.py` file since it is no longer needed.

---

**Action (14)**:
```
submit
```
**👀 Observation (14)**:
```
diff --git a/django/contrib/messages/storage/cookie.py b/django/contrib/messages/storage/cookie.py
index 1d390c7..7b035ea 100644
--- a/django/contrib/messages/storage/cookie.py
+++ b/django/contrib/messages/storage/cookie.py
@@ -18,9 +18,7 @@ class MessageEncoder(json.JSONEncoder):
         if isinstance(obj, Message):
             # Using 0/1 here instead of False/True to produce more compact json
             is_safedata = 1 if isinstance(obj.message, SafeData) else 0
-            message = [self.message_key, is_safedata, obj.level, obj.message]
-            if obj.extra_tags:
-                message.append(obj.extra_tags)
+            message = [self.message_key, is_safedata, obj.level, obj.message, obj.extra_tags or None]
             return message
         return super().default(obj)
 
@@ -35,7 +33,7 @@ class MessageDecoder(json.JSONDecoder):
             if obj[0] == MessageEncoder.message_key:
                 if obj[1]:
                     obj[3] = mark_safe(obj[3])
-                return Message(*obj[2:])
+                return Message(obj[2], obj[3], extra_tags=obj[4] if obj[4] is not None else "")
             return [self.process_messages(item) for item in obj]
         if isinstance(obj, dict):
             return {key: self.process_messages(value)
```
**️🧑‍🚒 Response (14)**:
The `reproduce_bug.py` file has been successfully removed. Now that we have fixed the issue and cleaned up the environment, we can submit our changes to the code base.

Let's submit the changes using the `submit` command.
```
submit
```
**🧠 State (14)**:
```
{"open_file": "/swe-agent__django/django/contrib/messages/storage/cookie.py", "working_dir": "/swe-agent__django"}
```
**💡 Thought (14)**:
The `reproduce_bug.py` file has been successfully removed. Now that we have fixed the issue and cleaned up the environment, we can submit our changes to the code base.

Let's submit the changes using the `submit` command.
</details>