### PR TITLE
SWE-agent[bot] PR to fix: Messages framework incorrectly serializes/deserializes extra_tags when it's an empty string

### DIFF
--- a/django/contrib/messages/storage/cookie.py
+++ b/django/contrib/messages/storage/cookie.py
@@ -19,8 +19,7 @@ class MessageEncoder(json.JSONEncoder):
             # Using 0/1 here instead of False/True to produce more compact json
             is_safedata = 1 if isinstance(obj.message, SafeData) else 0
             message = [self.message_key, is_safedata, obj.level, obj.message]
-            if obj.extra_tags:
-                message.append(obj.extra_tags)
+            message = [self.message_key, is_safedata, obj.level, obj.message, obj.extra_tags]
             return message
         return super().default(obj)
 


### PR DESCRIPTION
This is a PR opened by AI tool [SWE Agent](https://github.com/princeton-nlp/SWE-agent/) to close [#1](https://github.com/swe-agent/django/issues/1) (Messages framework incorrectly serializes/deserializes extra_tags when it's an empty string).

Closes #1.

<details>
<summary>Thought process ('trajectory') of SWE-agent (click to expand)</summary>

**Action (0)**:
```
create reproduce_bug.py
```
**👀 Observation (0)**:
```
[File: /swe-agent__django/reproduce_bug.py (1 lines total)]
1:
```
**️🧑‍🚒 Response (0)**:
First, let's start by reproducing the issue described. We'll create a new Python script named `reproduce_bug.py` and write the provided code snippet into it to verify the behavior of the serialization and deserialization process.
```
create reproduce_bug.py
```
**🧠 State (0)**:
```
{"open_file": "n/a", "working_dir": "/swe-agent__django"}
```
**💡 Thought (0)**:
First, let's start by reproducing the issue described. We'll create a new Python script named `reproduce_bug.py` and write the provided code snippet into it to verify the behavior of the serialization and deserialization process.

---

**Action (1)**:
```
edit 1:1
from django.conf import settings
settings.configure()  # Just to allow the following import
from django.contrib.messages.storage.base import Message
from django.contrib.messages.storage.cookie import MessageEncoder, MessageDecoder

original_message = Message(10, "Here is a message", extra_tags="")
encoded_message = MessageEncoder().encode(original_message)
decoded_message = MessageDecoder().decode(encoded_message)

print("Original extra_tags empty string:", original_message.extra_tags == "")
print("Decoded extra_tags is None:", decoded_message.extra_tags is None)
end_of_edit
```
**👀 Observation (1)**:
```
[File: /swe-agent__django/reproduce_bug.py (11 lines total)]
1:from django.conf import settings
2:settings.configure()  # Just to allow the following import
3:from django.contrib.messages.storage.base import Message
4:from django.contrib.messages.storage.cookie import MessageEncoder, MessageDecoder
5:
6:original_message = Message(10, "Here is a message", extra_tags="")
7:encoded_message = MessageEncoder().encode(original_message)
8:decoded_message = MessageDecoder().decode(encoded_message)
9:
10:print("Original extra_tags empty string:", original_message.extra_tags == "")
11:print("Decoded extra_tags is None:", decoded_message.extra_tags is None)
File updated. Please review the changes and make sure they are correct (correct indentation, no duplicate lines, etc). Edit the file again if necessary.
```
**️🧑‍🚒 Response (1)**:
Now let's paste in the example code from the issue to reproduce the bug.
```
edit 1:1
from django.conf import settings
settings.configure()  # Just to allow the following import
from django.contrib.messages.storage.base import Message
from django.contrib.messages.storage.cookie import MessageEncoder, MessageDecoder

original_message = Message(10, "Here is a message", extra_tags="")
encoded_message = MessageEncoder().encode(original_message)
decoded_message = MessageDecoder().decode(encoded_message)

print("Original extra_tags empty string:", original_message.extra_tags == "")
print("Decoded extra_tags is None:", decoded_message.extra_tags is None)
end_of_edit
```
**🧠 State (1)**:
```
{"open_file": "/swe-agent__django/reproduce_bug.py", "working_dir": "/swe-agent__django"}
```
**💡 Thought (1)**:
Now let's paste in the example code from the issue to reproduce the bug.

---

**Action (2)**:
```
python reproduce_bug.py
```
**👀 Observation (2)**:
```
Original extra_tags empty string: True
Decoded extra_tags is None: True
```
**️🧑‍🚒 Response (2)**:
Now let's run the script to see if we can reproduce the issue as described, where the `extra_tags` attribute changes from an empty string to `None` after serialization and deserialization.
```
python reproduce_bug.py
```
**🧠 State (2)**:
```
{"open_file": "/swe-agent__django/reproduce_bug.py", "working_dir": "/swe-agent__django"}
```
**💡 Thought (2)**:
Now let's run the script to see if we can reproduce the issue as described, where the `extra_tags` attribute changes from an empty string to `None` after serialization and deserialization.

---

**Action (3)**:
```
find_file "cookie.py" django/contrib/messages/storage
```
**👀 Observation (3)**:
```
Found 1 matches for "cookie.py" in /swe-agent__django/django/contrib/messages/storage:
/swe-agent__django/django/contrib/messages/storage/cookie.py
```
**️🧑‍🚒 Response (3)**:
We have successfully reproduced the issue where the `extra_tags` attribute changes from an empty string to `None` after serialization and deserialization. The next step is to locate the `MessageEncoder` and `MessageDecoder` classes in the Django source code to inspect and modify the serialization and deserialization logic.

Let's start by finding the file that contains the `MessageEncoder` and `MessageDecoder` classes. We know they are likely in the `django/contrib/messages/storage` directory, but we'll use the `find_file` command to locate the exact file.
```
find_file "cookie.py" django/contrib/messages/storage
```
**🧠 State (3)**:
```
{"open_file": "/swe-agent__django/reproduce_bug.py", "working_dir": "/swe-agent__django"}
```
**💡 Thought (3)**:
We have successfully reproduced the issue where the `extra_tags` attribute changes from an empty string to `None` after serialization and deserialization. The next step is to locate the `MessageEncoder` and `MessageDecoder` classes in the Django source code to inspect and modify the serialization and deserialization logic.

Let's start by finding the file that contains the `MessageEncoder` and `MessageDecoder` classes. We know they are likely in the `django/contrib/messages/storage` directory, but we'll use the `find_file` command to locate the exact file.

---

**Action (4)**:
```
open django/contrib/messages/storage/cookie.py
```
**👀 Observation (4)**:
```
[File: /swe-agent__django/django/contrib/messages/storage/cookie.py (169 lines total)]
1:import binascii
2:import json
3:
4:from django.conf import settings
5:from django.contrib.messages.storage.base import BaseStorage, Message
6:from django.core import signing
7:from django.http import SimpleCookie
8:from django.utils.safestring import SafeData, mark_safe
9:
10:
11:class MessageEncoder(json.JSONEncoder):
12:    """
13:    Compactly serialize instances of the ``Message`` class as JSON.
14:    """
15:    message_key = '__json_message'
16:
17:    def default(self, obj):
18:        if isinstance(obj, Message):
19:            # Using 0/1 here instead of False/True to produce more compact json
20:            is_safedata = 1 if isinstance(obj.message, SafeData) else 0
21:            message = [self.message_key, is_safedata, obj.level, obj.message]
22:            if obj.extra_tags:
23:                message.append(obj.extra_tags)
24:            return message
25:        return super().default(obj)
26:
27:
28:class MessageDecoder(json.JSONDecoder):
29:    """
30:    Decode JSON that includes serialized ``Message`` instances.
31:    """
32:
33:    def process_messages(self, obj):
34:        if isinstance(obj, list) and obj:
35:            if obj[0] == MessageEncoder.message_key:
36:                if obj[1]:
37:                    obj[3] = mark_safe(obj[3])
38:                return Message(*obj[2:])
39:            return [self.process_messages(item) for item in obj]
40:        if isinstance(obj, dict):
41:            return {key: self.process_messages(value)
42:                    for key, value in obj.items()}
43:        return obj
44:
45:    def decode(self, s, **kwargs):
46:        decoded = super().decode(s, **kwargs)
47:        return self.process_messages(decoded)
48:
49:
50:class MessageSerializer:
51:    def dumps(self, obj):
52:        return json.dumps(
53:            obj,
54:            separators=(',', ':'),
55:            cls=MessageEncoder,
56:        ).encode('latin-1')
57:
58:    def loads(self, data):
59:        return json.loads(data.decode('latin-1'), cls=MessageDecoder)
60:
61:
62:class CookieStorage(BaseStorage):
63:    """
64:    Store messages in a cookie.
65:    """
66:    cookie_name = 'messages'
67:    # uwsgi's default configuration enforces a maximum size of 4kb for all the
68:    # HTTP headers. In order to leave some room for other cookies and headers,
69:    # restrict the session cookie to 1/2 of 4kb. See #18781.
70:    max_cookie_size = 2048
71:    not_finished = '__messagesnotfinished__'
72:    key_salt = 'django.contrib.messages'
73:
74:    def __init__(self, *args, **kwargs):
75:        super().__init__(*args, **kwargs)
76:        self.signer = signing.get_cookie_signer(salt=self.key_salt)
77:
78:    def _get(self, *args, **kwargs):
79:        """
80:        Retrieve a list of messages from the messages cookie. If the
81:        not_finished sentinel value is found at the end of the message list,
82:        remove it and return a result indicating that not all messages were
83:        retrieved by this storage.
84:        """
85:        data = self.request.COOKIES.get(self.cookie_name)
86:        messages = self._decode(data)
87:        all_retrieved = not (messages and messages[-1] == self.not_finished)
88:        if messages and not all_retrieved:
89:            # remove the sentinel value
90:            messages.pop()
91:        return messages, all_retrieved
92:
93:    def _update_cookie(self, encoded_data, response):
94:        """
95:        Either set the cookie with the encoded data if there is any data to
96:        store, or delete the cookie.
97:        """
98:        if encoded_data:
99:            response.set_cookie(
100:                self.cookie_name, encoded_data,
(69 more lines below)
```
**️🧑‍🚒 Response (4)**:
The file containing the `MessageEncoder` and `MessageDecoder` classes is located at `/swe-agent__django/django/contrib/messages/storage/cookie.py`. Let's open this file and inspect the relevant code sections to understand how `extra_tags` is being handled during serialization and deserialization.
```
open django/contrib/messages/storage/cookie.py
```
**🧠 State (4)**:
```
{"open_file": "/swe-agent__django/reproduce_bug.py", "working_dir": "/swe-agent__django"}
```
**💡 Thought (4)**:
The file containing the `MessageEncoder` and `MessageDecoder` classes is located at `/swe-agent__django/django/contrib/messages/storage/cookie.py`. Let's open this file and inspect the relevant code sections to understand how `extra_tags` is being handled during serialization and deserialization.

---

**Action (5)**:
```
edit 22:24
            message = [self.message_key, is_safedata, obj.level, obj.message, obj.extra_tags]
            return message
end_of_edit
```
**👀 Observation (5)**:
```
[File: /swe-agent__django/django/contrib/messages/storage/cookie.py (168 lines total)]
1:import binascii
2:import json
3:
4:from django.conf import settings
5:from django.contrib.messages.storage.base import BaseStorage, Message
6:from django.core import signing
7:from django.http import SimpleCookie
8:from django.utils.safestring import SafeData, mark_safe
9:
10:
11:class MessageEncoder(json.JSONEncoder):
12:    """
13:    Compactly serialize instances of the ``Message`` class as JSON.
14:    """
15:    message_key = '__json_message'
16:
17:    def default(self, obj):
18:        if isinstance(obj, Message):
19:            # Using 0/1 here instead of False/True to produce more compact json
20:            is_safedata = 1 if isinstance(obj.message, SafeData) else 0
21:            message = [self.message_key, is_safedata, obj.level, obj.message]
22:            message = [self.message_key, is_safedata, obj.level, obj.message, obj.extra_tags]
23:            return message
24:        return super().default(obj)
25:
26:
27:class MessageDecoder(json.JSONDecoder):
28:    """
29:    Decode JSON that includes serialized ``Message`` instances.
30:    """
31:
32:    def process_messages(self, obj):
33:        if isinstance(obj, list) and obj:
34:            if obj[0] == MessageEncoder.message_key:
35:                if obj[1]:
36:                    obj[3] = mark_safe(obj[3])
37:                return Message(*obj[2:])
38:            return [self.process_messages(item) for item in obj]
39:        if isinstance(obj, dict):
40:            return {key: self.process_messages(value)
41:                    for key, value in obj.items()}
42:        return obj
43:
44:    def decode(self, s, **kwargs):
45:        decoded = super().decode(s, **kwargs)
46:        return self.process_messages(decoded)
47:
48:
49:class MessageSerializer:
50:    def dumps(self, obj):
51:        return json.dumps(
52:            obj,
53:            separators=(',', ':'),
54:            cls=MessageEncoder,
55:        ).encode('latin-1')
56:
57:    def loads(self, data):
58:        return json.loads(data.decode('latin-1'), cls=MessageDecoder)
59:
60:
61:class CookieStorage(BaseStorage):
62:    """
63:    Store messages in a cookie.
64:    """
65:    cookie_name = 'messages'
66:    # uwsgi's default configuration enforces a maximum size of 4kb for all the
67:    # HTTP headers. In order to leave some room for other cookies and headers,
68:    # restrict the session cookie to 1/2 of 4kb. See #18781.
69:    max_cookie_size = 2048
70:    not_finished = '__messagesnotfinished__'
71:    key_salt = 'django.contrib.messages'
72:
73:    def __init__(self, *args, **kwargs):
74:        super().__init__(*args, **kwargs)
75:        self.signer = signing.get_cookie_signer(salt=self.key_salt)
76:
77:    def _get(self, *args, **kwargs):
78:        """
79:        Retrieve a list of messages from the messages cookie. If the
80:        not_finished sentinel value is found at the end of the message list,
81:        remove it and return a result indicating that not all messages were
82:        retrieved by this storage.
83:        """
84:        data = self.request.COOKIES.get(self.cookie_name)
85:        messages = self._decode(data)
86:        all_retrieved = not (messages and messages[-1] == self.not_finished)
87:        if messages and not all_retrieved:
88:            # remove the sentinel value
89:            messages.pop()
90:        return messages, all_retrieved
91:
92:    def _update_cookie(self, encoded_data, response):
93:        """
94:        Either set the cookie with the encoded data if there is any data to
95:        store, or delete the cookie.
96:        """
97:        if encoded_data:
98:            response.set_cookie(
99:                self.cookie_name, encoded_data,
100:                domain=settings.SESSION_COOKIE_DOMAIN,
(68 more lines below)
File updated. Please review the changes and make sure they are correct (correct indentation, no duplicate lines, etc). Edit the file again if necessary.
```
**️🧑‍🚒 Response (5)**:
We have the `cookie.py` file open, which contains the `MessageEncoder` and `MessageDecoder` classes. The issue arises because the `MessageEncoder` only appends `extra_tags` to the message if it is truthy (line 22). This causes an empty string to be excluded from the serialization process, leading to it being absent and interpreted as `None` upon deserialization.

To fix this, we need to modify the `MessageEncoder` to ensure `extra_tags` is always included in the serialized message, even if it's an empty string. Let's edit the code to include `extra_tags` unconditionally.
```
edit 22:24
            message = [self.message_key, is_safedata, obj.level, obj.message, obj.extra_tags]
            return message
end_of_edit
```
**🧠 State (5)**:
```
{"open_file": "/swe-agent__django/django/contrib/messages/storage/cookie.py", "working_dir": "/swe-agent__django"}
```
**💡 Thought (5)**:
We have the `cookie.py` file open, which contains the `MessageEncoder` and `MessageDecoder` classes. The issue arises because the `MessageEncoder` only appends `extra_tags` to the message if it is truthy (line 22). This causes an empty string to be excluded from the serialization process, leading to it being absent and interpreted as `None` upon deserialization.

To fix this, we need to modify the `MessageEncoder` to ensure `extra_tags` is always included in the serialized message, even if it's an empty string. Let's edit the code to include `extra_tags` unconditionally.

---

**Action (6)**:
```
python reproduce_bug.py
```
**👀 Observation (6)**:
```
Original extra_tags empty string: True
Decoded extra_tags is None: False
```
**️🧑‍🚒 Response (6)**:
The modification to always include `extra_tags` in the serialized message has been successfully applied. Now, let's re-run the `reproduce_bug.py` script to ensure that the issue has been resolved and that `extra_tags` remains an empty string after serialization and deserialization, rather than turning into `None`.
```
python reproduce_bug.py
```
**🧠 State (6)**:
```
{"open_file": "/swe-agent__django/django/contrib/messages/storage/cookie.py", "working_dir": "/swe-agent__django"}
```
**💡 Thought (6)**:
The modification to always include `extra_tags` in the serialized message has been successfully applied. Now, let's re-run the `reproduce_bug.py` script to ensure that the issue has been resolved and that `extra_tags` remains an empty string after serialization and deserialization, rather than turning into `None`.

---

**Action (7)**:
```
rm reproduce_bug.py
```
**👀 Observation (7)**:
```

```
**️🧑‍🚒 Response (7)**:
The output confirms that the issue has been resolved: `decoded_message.extra_tags` is no longer `None` but retains its original empty string value. This means our fix is effective.

Since the bug has been fixed and verified, we can clean up by removing the `reproduce_bug.py` script, as it is no longer needed.
```
rm reproduce_bug.py
```
**🧠 State (7)**:
```
{"open_file": "/swe-agent__django/django/contrib/messages/storage/cookie.py", "working_dir": "/swe-agent__django"}
```
**💡 Thought (7)**:
The output confirms that the issue has been resolved: `decoded_message.extra_tags` is no longer `None` but retains its original empty string value. This means our fix is effective.

Since the bug has been fixed and verified, we can clean up by removing the `reproduce_bug.py` script, as it is no longer needed.

---

**Action (8)**:
```
submit
```
**👀 Observation (8)**:
```
diff --git a/django/contrib/messages/storage/cookie.py b/django/contrib/messages/storage/cookie.py
index 1d390c7..019f6c2 100644
--- a/django/contrib/messages/storage/cookie.py
+++ b/django/contrib/messages/storage/cookie.py
@@ -19,8 +19,7 @@ class MessageEncoder(json.JSONEncoder):
             # Using 0/1 here instead of False/True to produce more compact json
             is_safedata = 1 if isinstance(obj.message, SafeData) else 0
             message = [self.message_key, is_safedata, obj.level, obj.message]
-            if obj.extra_tags:
-                message.append(obj.extra_tags)
+            message = [self.message_key, is_safedata, obj.level, obj.message, obj.extra_tags]
             return message
         return super().default(obj)
```
**️🧑‍🚒 Response (8)**:
The `reproduce_bug.py` file has been successfully removed. Now that we have fixed the issue and verified the solution, we can submit our changes to the code base. Let's proceed with submitting the changes using the `submit` command.
```
submit
```
**🧠 State (8)**:
```
{"open_file": "/swe-agent__django/django/contrib/messages/storage/cookie.py", "working_dir": "/swe-agent__django"}
```
**💡 Thought (8)**:
The `reproduce_bug.py` file has been successfully removed. Now that we have fixed the issue and verified the solution, we can submit our changes to the code base. Let's proceed with submitting the changes using the `submit` command.
</details>