### PR TITLE
SWE-agent[bot] PR to fix: Messages framework incorrectly serializes/deserializes extra_tags when it's an empty string

### DIFF
--- a/django/contrib/messages/storage/cookie.py
+++ b/django/contrib/messages/storage/cookie.py
@@ -19,7 +19,7 @@ class MessageEncoder(json.JSONEncoder):
             # Using 0/1 here instead of False/True to produce more compact json
             is_safedata = 1 if isinstance(obj.message, SafeData) else 0
             message = [self.message_key, is_safedata, obj.level, obj.message]
-            if obj.extra_tags:
+            if obj.extra_tags is not None:
                 message.append(obj.extra_tags)
             return message
         return super().default(obj)


### PR DESCRIPTION
This is a PR opened by AI tool [SWE Agent](https://github.com/princeton-nlp/SWE-agent/) to close [#1](https://github.com/swe-agent/django/issues/1) (Messages framework incorrectly serializes/deserializes extra_tags when it's an empty string).

Closes #1.

<details>
<summary>Thought process ('trajectory') of SWE-agent (click to expand)</summary>

**Action (0)**:
```
create reproduce_bug.py
```
**👀 Observation (0)**:
```
[File: /swe-agent__django/reproduce_bug.py (1 lines total)]
1:
```
**️🧑‍🚒 Response (0)**:
First, let's start by reproducing the issue described. We'll create a new Python script named `reproduce_bug.py` and write the provided code snippet into it to verify the behavior of the serialization and deserialization process.
```
create reproduce_bug.py
```
**🧠 State (0)**:
```
{"open_file": "n/a", "working_dir": "/swe-agent__django"}
```
**💡 Thought (0)**:
First, let's start by reproducing the issue described. We'll create a new Python script named `reproduce_bug.py` and write the provided code snippet into it to verify the behavior of the serialization and deserialization process.

---

**Action (1)**:
```
edit 1:1
from django.conf import settings
settings.configure()  # Just to allow the following import
from django.contrib.messages.storage.base import Message
from django.contrib.messages.storage.cookie import MessageEncoder, MessageDecoder

original_message = Message(10, "Here is a message", extra_tags="")
encoded_message = MessageEncoder().encode(original_message)
decoded_message = MessageDecoder().decode(encoded_message)

print("Original extra_tags empty string:", original_message.extra_tags == "")
print("Decoded extra_tags is None:", decoded_message.extra_tags is None)
end_of_edit
```
**👀 Observation (1)**:
```
[File: /swe-agent__django/reproduce_bug.py (11 lines total)]
1:from django.conf import settings
2:settings.configure()  # Just to allow the following import
3:from django.contrib.messages.storage.base import Message
4:from django.contrib.messages.storage.cookie import MessageEncoder, MessageDecoder
5:
6:original_message = Message(10, "Here is a message", extra_tags="")
7:encoded_message = MessageEncoder().encode(original_message)
8:decoded_message = MessageDecoder().decode(encoded_message)
9:
10:print("Original extra_tags empty string:", original_message.extra_tags == "")
11:print("Decoded extra_tags is None:", decoded_message.extra_tags is None)
File updated. Please review the changes and make sure they are correct (correct indentation, no duplicate lines, etc). Edit the file again if necessary.
```
**️🧑‍🚒 Response (1)**:
Now let's paste in the example code from the issue to reproduce the bug.
```
edit 1:1
from django.conf import settings
settings.configure()  # Just to allow the following import
from django.contrib.messages.storage.base import Message
from django.contrib.messages.storage.cookie import MessageEncoder, MessageDecoder

original_message = Message(10, "Here is a message", extra_tags="")
encoded_message = MessageEncoder().encode(original_message)
decoded_message = MessageDecoder().decode(encoded_message)

print("Original extra_tags empty string:", original_message.extra_tags == "")
print("Decoded extra_tags is None:", decoded_message.extra_tags is None)
end_of_edit
```
**🧠 State (1)**:
```
{"open_file": "/swe-agent__django/reproduce_bug.py", "working_dir": "/swe-agent__django"}
```
**💡 Thought (1)**:
Now let's paste in the example code from the issue to reproduce the bug.

---

**Action (2)**:
```
python reproduce_bug.py
```
**👀 Observation (2)**:
```
Original extra_tags empty string: True
Decoded extra_tags is None: True
```
**️🧑‍🚒 Response (2)**:
Let's run the script to see if we can reproduce the issue as described, where the `extra_tags` attribute changes from an empty string to `None` after serialization and deserialization.
```
python reproduce_bug.py
```
**🧠 State (2)**:
```
{"open_file": "/swe-agent__django/reproduce_bug.py", "working_dir": "/swe-agent__django"}
```
**💡 Thought (2)**:
Let's run the script to see if we can reproduce the issue as described, where the `extra_tags` attribute changes from an empty string to `None` after serialization and deserialization.

---

**Action (3)**:
```
find_file "cookie.py"
```
**👀 Observation (3)**:
```
Found 4 matches for "cookie.py" in /swe-agent__django:
/swe-agent__django/build/lib/django/contrib/messages/storage/cookie.py
/swe-agent__django/build/lib/django/http/cookie.py
/swe-agent__django/django/contrib/messages/storage/cookie.py
/swe-agent__django/django/http/cookie.py
```
**️🧑‍🚒 Response (3)**:
We have successfully reproduced the issue where the `extra_tags` attribute changes from an empty string to `None` after serialization and deserialization. The next step is to locate the `MessageEncoder` and `MessageDecoder` classes in the Django source code to inspect and modify the serialization logic.

Let's start by finding the file that contains the `MessageEncoder` class. We'll use the `find_file` command to search for it in the current directory and subdirectories.
```
find_file "cookie.py"
```
**🧠 State (3)**:
```
{"open_file": "/swe-agent__django/reproduce_bug.py", "working_dir": "/swe-agent__django"}
```
**💡 Thought (3)**:
We have successfully reproduced the issue where the `extra_tags` attribute changes from an empty string to `None` after serialization and deserialization. The next step is to locate the `MessageEncoder` and `MessageDecoder` classes in the Django source code to inspect and modify the serialization logic.

Let's start by finding the file that contains the `MessageEncoder` class. We'll use the `find_file` command to search for it in the current directory and subdirectories.

---

**Action (4)**:
```
open django/contrib/messages/storage/cookie.py
```
**👀 Observation (4)**:
```
[File: /swe-agent__django/django/contrib/messages/storage/cookie.py (169 lines total)]
1:import binascii
2:import json
3:
4:from django.conf import settings
5:from django.contrib.messages.storage.base import BaseStorage, Message
6:from django.core import signing
7:from django.http import SimpleCookie
8:from django.utils.safestring import SafeData, mark_safe
9:
10:
11:class MessageEncoder(json.JSONEncoder):
12:    """
13:    Compactly serialize instances of the ``Message`` class as JSON.
14:    """
15:    message_key = '__json_message'
16:
17:    def default(self, obj):
18:        if isinstance(obj, Message):
19:            # Using 0/1 here instead of False/True to produce more compact json
20:            is_safedata = 1 if isinstance(obj.message, SafeData) else 0
21:            message = [self.message_key, is_safedata, obj.level, obj.message]
22:            if obj.extra_tags:
23:                message.append(obj.extra_tags)
24:            return message
25:        return super().default(obj)
26:
27:
28:class MessageDecoder(json.JSONDecoder):
29:    """
30:    Decode JSON that includes serialized ``Message`` instances.
31:    """
32:
33:    def process_messages(self, obj):
34:        if isinstance(obj, list) and obj:
35:            if obj[0] == MessageEncoder.message_key:
36:                if obj[1]:
37:                    obj[3] = mark_safe(obj[3])
38:                return Message(*obj[2:])
39:            return [self.process_messages(item) for item in obj]
40:        if isinstance(obj, dict):
41:            return {key: self.process_messages(value)
42:                    for key, value in obj.items()}
43:        return obj
44:
45:    def decode(self, s, **kwargs):
46:        decoded = super().decode(s, **kwargs)
47:        return self.process_messages(decoded)
48:
49:
50:class MessageSerializer:
51:    def dumps(self, obj):
52:        return json.dumps(
53:            obj,
54:            separators=(',', ':'),
55:            cls=MessageEncoder,
56:        ).encode('latin-1')
57:
58:    def loads(self, data):
59:        return json.loads(data.decode('latin-1'), cls=MessageDecoder)
60:
61:
62:class CookieStorage(BaseStorage):
63:    """
64:    Store messages in a cookie.
65:    """
66:    cookie_name = 'messages'
67:    # uwsgi's default configuration enforces a maximum size of 4kb for all the
68:    # HTTP headers. In order to leave some room for other cookies and headers,
69:    # restrict the session cookie to 1/2 of 4kb. See #18781.
70:    max_cookie_size = 2048
71:    not_finished = '__messagesnotfinished__'
72:    key_salt = 'django.contrib.messages'
73:
74:    def __init__(self, *args, **kwargs):
75:        super().__init__(*args, **kwargs)
76:        self.signer = signing.get_cookie_signer(salt=self.key_salt)
77:
78:    def _get(self, *args, **kwargs):
79:        """
80:        Retrieve a list of messages from the messages cookie. If the
81:        not_finished sentinel value is found at the end of the message list,
82:        remove it and return a result indicating that not all messages were
83:        retrieved by this storage.
84:        """
85:        data = self.request.COOKIES.get(self.cookie_name)
86:        messages = self._decode(data)
87:        all_retrieved = not (messages and messages[-1] == self.not_finished)
88:        if messages and not all_retrieved:
89:            # remove the sentinel value
90:            messages.pop()
91:        return messages, all_retrieved
92:
93:    def _update_cookie(self, encoded_data, response):
94:        """
95:        Either set the cookie with the encoded data if there is any data to
96:        store, or delete the cookie.
97:        """
98:        if encoded_data:
99:            response.set_cookie(
100:                self.cookie_name, encoded_data,
(69 more lines below)
```
**️🧑‍🚒 Response (4)**:
The file we are interested in is `/swe-agent__django/django/contrib/messages/storage/cookie.py` as it pertains to the `MessageEncoder` and `MessageDecoder` classes used in the Django messages framework. Let's open this file to inspect the serialization and deserialization logic.
```
open django/contrib/messages/storage/cookie.py
```
**🧠 State (4)**:
```
{"open_file": "/swe-agent__django/reproduce_bug.py", "working_dir": "/swe-agent__django"}
```
**💡 Thought (4)**:
The file we are interested in is `/swe-agent__django/django/contrib/messages/storage/cookie.py` as it pertains to the `MessageEncoder` and `MessageDecoder` classes used in the Django messages framework. Let's open this file to inspect the serialization and deserialization logic.

---

**Action (5)**:
```
edit 22:22
            if obj.extra_tags is not None:
                message.append(obj.extra_tags)
end_of_edit
```
**👀 Observation (5)**:
```
[File: /swe-agent__django/django/contrib/messages/storage/cookie.py (170 lines total)]
1:import binascii
2:import json
3:
4:from django.conf import settings
5:from django.contrib.messages.storage.base import BaseStorage, Message
6:from django.core import signing
7:from django.http import SimpleCookie
8:from django.utils.safestring import SafeData, mark_safe
9:
10:
11:class MessageEncoder(json.JSONEncoder):
12:    """
13:    Compactly serialize instances of the ``Message`` class as JSON.
14:    """
15:    message_key = '__json_message'
16:
17:    def default(self, obj):
18:        if isinstance(obj, Message):
19:            # Using 0/1 here instead of False/True to produce more compact json
20:            is_safedata = 1 if isinstance(obj.message, SafeData) else 0
21:            message = [self.message_key, is_safedata, obj.level, obj.message]
22:            if obj.extra_tags is not None:
23:                message.append(obj.extra_tags)
24:                message.append(obj.extra_tags)
25:            return message
26:        return super().default(obj)
27:
28:
29:class MessageDecoder(json.JSONDecoder):
30:    """
31:    Decode JSON that includes serialized ``Message`` instances.
32:    """
33:
34:    def process_messages(self, obj):
35:        if isinstance(obj, list) and obj:
36:            if obj[0] == MessageEncoder.message_key:
37:                if obj[1]:
38:                    obj[3] = mark_safe(obj[3])
39:                return Message(*obj[2:])
40:            return [self.process_messages(item) for item in obj]
41:        if isinstance(obj, dict):
42:            return {key: self.process_messages(value)
43:                    for key, value in obj.items()}
44:        return obj
45:
46:    def decode(self, s, **kwargs):
47:        decoded = super().decode(s, **kwargs)
48:        return self.process_messages(decoded)
49:
50:
51:class MessageSerializer:
52:    def dumps(self, obj):
53:        return json.dumps(
54:            obj,
55:            separators=(',', ':'),
56:            cls=MessageEncoder,
57:        ).encode('latin-1')
58:
59:    def loads(self, data):
60:        return json.loads(data.decode('latin-1'), cls=MessageDecoder)
61:
62:
63:class CookieStorage(BaseStorage):
64:    """
65:    Store messages in a cookie.
66:    """
67:    cookie_name = 'messages'
68:    # uwsgi's default configuration enforces a maximum size of 4kb for all the
69:    # HTTP headers. In order to leave some room for other cookies and headers,
70:    # restrict the session cookie to 1/2 of 4kb. See #18781.
71:    max_cookie_size = 2048
72:    not_finished = '__messagesnotfinished__'
73:    key_salt = 'django.contrib.messages'
74:
75:    def __init__(self, *args, **kwargs):
76:        super().__init__(*args, **kwargs)
77:        self.signer = signing.get_cookie_signer(salt=self.key_salt)
78:
79:    def _get(self, *args, **kwargs):
80:        """
81:        Retrieve a list of messages from the messages cookie. If the
82:        not_finished sentinel value is found at the end of the message list,
83:        remove it and return a result indicating that not all messages were
84:        retrieved by this storage.
85:        """
86:        data = self.request.COOKIES.get(self.cookie_name)
87:        messages = self._decode(data)
88:        all_retrieved = not (messages and messages[-1] == self.not_finished)
89:        if messages and not all_retrieved:
90:            # remove the sentinel value
91:            messages.pop()
92:        return messages, all_retrieved
93:
94:    def _update_cookie(self, encoded_data, response):
95:        """
96:        Either set the cookie with the encoded data if there is any data to
97:        store, or delete the cookie.
98:        """
99:        if encoded_data:
100:            response.set_cookie(
(70 more lines below)
File updated. Please review the changes and make sure they are correct (correct indentation, no duplicate lines, etc). Edit the file again if necessary.
```
**️🧑‍🚒 Response (5)**:
We have the `MessageEncoder` and `MessageDecoder` classes open in the file. The issue arises because the `MessageEncoder` does not handle the case where `extra_tags` is an empty string distinctly from `None`. We need to modify the serialization logic to ensure that an empty string remains an empty string after serialization and deserialization.

Let's edit the `MessageEncoder` class to handle the empty string case correctly. We'll modify the condition in line 22 to check explicitly if `extra_tags` is not `None` instead of checking its truthiness.
```
edit 22:22
            if obj.extra_tags is not None:
                message.append(obj.extra_tags)
end_of_edit
```
**🧠 State (5)**:
```
{"open_file": "/swe-agent__django/django/contrib/messages/storage/cookie.py", "working_dir": "/swe-agent__django"}
```
**💡 Thought (5)**:
We have the `MessageEncoder` and `MessageDecoder` classes open in the file. The issue arises because the `MessageEncoder` does not handle the case where `extra_tags` is an empty string distinctly from `None`. We need to modify the serialization logic to ensure that an empty string remains an empty string after serialization and deserialization.

Let's edit the `MessageEncoder` class to handle the empty string case correctly. We'll modify the condition in line 22 to check explicitly if `extra_tags` is not `None` instead of checking its truthiness.

---

**Action (6)**:
```
edit 24:24
end_of_edit
```
**👀 Observation (6)**:
```
[File: /swe-agent__django/django/contrib/messages/storage/cookie.py (169 lines total)]
1:import binascii
2:import json
3:
4:from django.conf import settings
5:from django.contrib.messages.storage.base import BaseStorage, Message
6:from django.core import signing
7:from django.http import SimpleCookie
8:from django.utils.safestring import SafeData, mark_safe
9:
10:
11:class MessageEncoder(json.JSONEncoder):
12:    """
13:    Compactly serialize instances of the ``Message`` class as JSON.
14:    """
15:    message_key = '__json_message'
16:
17:    def default(self, obj):
18:        if isinstance(obj, Message):
19:            # Using 0/1 here instead of False/True to produce more compact json
20:            is_safedata = 1 if isinstance(obj.message, SafeData) else 0
21:            message = [self.message_key, is_safedata, obj.level, obj.message]
22:            if obj.extra_tags is not None:
23:                message.append(obj.extra_tags)
24:            return message
25:        return super().default(obj)
26:
27:
28:class MessageDecoder(json.JSONDecoder):
29:    """
30:    Decode JSON that includes serialized ``Message`` instances.
31:    """
32:
33:    def process_messages(self, obj):
34:        if isinstance(obj, list) and obj:
35:            if obj[0] == MessageEncoder.message_key:
36:                if obj[1]:
37:                    obj[3] = mark_safe(obj[3])
38:                return Message(*obj[2:])
39:            return [self.process_messages(item) for item in obj]
40:        if isinstance(obj, dict):
41:            return {key: self.process_messages(value)
42:                    for key, value in obj.items()}
43:        return obj
44:
45:    def decode(self, s, **kwargs):
46:        decoded = super().decode(s, **kwargs)
47:        return self.process_messages(decoded)
48:
49:
50:class MessageSerializer:
51:    def dumps(self, obj):
52:        return json.dumps(
53:            obj,
54:            separators=(',', ':'),
55:            cls=MessageEncoder,
56:        ).encode('latin-1')
57:
58:    def loads(self, data):
59:        return json.loads(data.decode('latin-1'), cls=MessageDecoder)
60:
61:
62:class CookieStorage(BaseStorage):
63:    """
64:    Store messages in a cookie.
65:    """
66:    cookie_name = 'messages'
67:    # uwsgi's default configuration enforces a maximum size of 4kb for all the
68:    # HTTP headers. In order to leave some room for other cookies and headers,
69:    # restrict the session cookie to 1/2 of 4kb. See #18781.
70:    max_cookie_size = 2048
71:    not_finished = '__messagesnotfinished__'
72:    key_salt = 'django.contrib.messages'
73:
74:    def __init__(self, *args, **kwargs):
75:        super().__init__(*args, **kwargs)
76:        self.signer = signing.get_cookie_signer(salt=self.key_salt)
77:
78:    def _get(self, *args, **kwargs):
79:        """
80:        Retrieve a list of messages from the messages cookie. If the
81:        not_finished sentinel value is found at the end of the message list,
82:        remove it and return a result indicating that not all messages were
83:        retrieved by this storage.
84:        """
85:        data = self.request.COOKIES.get(self.cookie_name)
86:        messages = self._decode(data)
87:        all_retrieved = not (messages and messages[-1] == self.not_finished)
88:        if messages and not all_retrieved:
89:            # remove the sentinel value
90:            messages.pop()
91:        return messages, all_retrieved
92:
93:    def _update_cookie(self, encoded_data, response):
94:        """
95:        Either set the cookie with the encoded data if there is any data to
96:        store, or delete the cookie.
97:        """
98:        if encoded_data:
99:            response.set_cookie(
100:                self.cookie_name, encoded_data,
(69 more lines below)
File updated. Please review the changes and make sure they are correct (correct indentation, no duplicate lines, etc). Edit the file again if necessary.
```
**️🧑‍🚒 Response (6)**:
It looks like there was an accidental duplication of the line appending `extra_tags` in the `MessageEncoder`. Let's correct this by removing the duplicate line.

```
edit 24:24
end_of_edit
```
**🧠 State (6)**:
```
{"open_file": "/swe-agent__django/django/contrib/messages/storage/cookie.py", "working_dir": "/swe-agent__django"}
```
**💡 Thought (6)**:
It looks like there was an accidental duplication of the line appending `extra_tags` in the `MessageEncoder`. Let's correct this by removing the duplicate line.

---

**Action (7)**:
```
python reproduce_bug.py
```
**👀 Observation (7)**:
```
Original extra_tags empty string: True
Decoded extra_tags is None: False
```
**️🧑‍🚒 Response (7)**:
The duplicate line has been successfully removed. Now, let's re-run the `reproduce_bug.py` script to ensure that the changes have resolved the issue and that `extra_tags` remains an empty string after serialization and deserialization.
```
python reproduce_bug.py
```
**🧠 State (7)**:
```
{"open_file": "/swe-agent__django/django/contrib/messages/storage/cookie.py", "working_dir": "/swe-agent__django"}
```
**💡 Thought (7)**:
The duplicate line has been successfully removed. Now, let's re-run the `reproduce_bug.py` script to ensure that the changes have resolved the issue and that `extra_tags` remains an empty string after serialization and deserialization.

---

**Action (8)**:
```
rm reproduce_bug.py
```
**👀 Observation (8)**:
```

```
**️🧑‍🚒 Response (8)**:
The output confirms that the issue has been resolved: `extra_tags` remains an empty string after serialization and deserialization, as indicated by `Decoded extra_tags is None: False`.

Now that the fix has been verified, we can clean up by removing the `reproduce_bug.py` script since it's no longer needed.
```
rm reproduce_bug.py
```
**🧠 State (8)**:
```
{"open_file": "/swe-agent__django/django/contrib/messages/storage/cookie.py", "working_dir": "/swe-agent__django"}
```
**💡 Thought (8)**:
The output confirms that the issue has been resolved: `extra_tags` remains an empty string after serialization and deserialization, as indicated by `Decoded extra_tags is None: False`.

Now that the fix has been verified, we can clean up by removing the `reproduce_bug.py` script since it's no longer needed.

---

**Action (9)**:
```
submit
```
**👀 Observation (9)**:
```
diff --git a/django/contrib/messages/storage/cookie.py b/django/contrib/messages/storage/cookie.py
index 1d390c7..e48d4ed 100644
--- a/django/contrib/messages/storage/cookie.py
+++ b/django/contrib/messages/storage/cookie.py
@@ -19,7 +19,7 @@ class MessageEncoder(json.JSONEncoder):
             # Using 0/1 here instead of False/True to produce more compact json
             is_safedata = 1 if isinstance(obj.message, SafeData) else 0
             message = [self.message_key, is_safedata, obj.level, obj.message]
-            if obj.extra_tags:
+            if obj.extra_tags is not None:
                 message.append(obj.extra_tags)
             return message
         return super().default(obj)
```
**️🧑‍🚒 Response (9)**:
The cleanup is complete. Now that we have fixed the issue and verified the solution, we can submit our changes to the code base. Let's proceed with submitting the changes using the `submit` command.
```
submit
```
**🧠 State (9)**:
```
{"open_file": "/swe-agent__django/django/contrib/messages/storage/cookie.py", "working_dir": "/swe-agent__django"}
```
**💡 Thought (9)**:
The cleanup is complete. Now that we have fixed the issue and verified the solution, we can submit our changes to the code base. Let's proceed with submitting the changes using the `submit` command.
</details>